### PR TITLE
fix: fixed to perform instant matching

### DIFF
--- a/orderbook/src/naive_impl.rs
+++ b/orderbook/src/naive_impl.rs
@@ -455,7 +455,8 @@ impl<'a> OrderBook<'a> for OrderBookNaiveImpl {
             cmd.action = order.action;
             cmd.uid = order.uid;
             cmd.order_id = order.order_id;
-            
+            cmd.size = order.size;
+
             // Try matching after price change
             let total_filled = self.try_match(cmd, order.filled);
             order.filled = total_filled;        

--- a/orderbook/src/naive_impl.rs
+++ b/orderbook/src/naive_impl.rs
@@ -278,7 +278,7 @@ impl OrderBookNaiveImpl {
                     }
                 }
 
-                if bucket.get_num_orders() == 0 {
+                if bucket.get_total_volume() == 0 {
                     buckets_to_remove.push(bucket_price);
                 }
             }
@@ -419,61 +419,57 @@ impl<'a> OrderBook<'a> for OrderBookNaiveImpl {
     }
 
     fn move_order(&mut self, cmd: &mut OrderCommand) -> Result<(), OrderBookError> {
-        if let Some(mut order) = self.order_id_map.remove(&cmd.order_id) {
+        let order = self.order_id_map.get(&cmd.order_id).cloned();
+        
+        if let Some(mut order) = order {
             if order.uid != cmd.uid {
-                self.order_id_map.insert(order.order_id, order); // re-insert
                 return Err(OrderBookError::UnknownOrderId);
             }
 
+            // Reserved price risk check for exchange bids
             if self.symbol_spec.symbol_type == SymbolType::CurrencyExchangePair
                 && order.action == OrderAction::Bid
                 && cmd.price > order.reserve_bid_price
             {
-                // Put the order back before returning
-                self.order_id_map.insert(order.order_id, order);
                 return Err(OrderBookError::MoveFailedPriceOverRiskLimit);
             }
 
             // Remove from old bucket
-            let old_buckets = if order.action == OrderAction::Ask {
-                &mut self.ask_buckets
-            } else {
-                &mut self.bid_buckets
-            };
-            let mut remove_bucket = false;
+            let old_buckets = self.get_buckets_mut(order.action);
             if let Some(bucket) = old_buckets.get_mut(&order.price) {
                 bucket.remove(order.order_id, order.uid);
                 if bucket.get_num_orders() == 0 {
-                    remove_bucket = true;
+                    old_buckets.remove(&order.price);
                 }
             }
-            if remove_bucket {
-                old_buckets.remove(&order.price);
-            }
 
+            // Update order price
             order.price = cmd.price;
+            
+            // Fill action field for events handling
             cmd.action = order.action;
-            cmd.uid = order.uid;
-            cmd.order_id = order.order_id;
+
             cmd.size = order.size;
 
             // Try matching after price change
             let total_filled = self.try_match(cmd, order.filled);
             order.filled = total_filled;
 
-            // Insert into new bucket only if partially filled or not filled at all
-            if order.size > order.filled {
-                let new_buckets = if order.action == OrderAction::Ask {
-                    &mut self.ask_buckets
-                } else {
-                    &mut self.bid_buckets
-                };
-                let bucket = new_buckets
-                    .entry(order.price)
-                    .or_insert_with(|| OrdersBucketNaive::new(order.price));
-                bucket.put(&order);
-                self.order_id_map.insert(order.order_id, order);
+            // If order was fully matched, remove it from order book
+            if order.filled == order.size {
+                self.order_id_map.remove(&cmd.order_id);
+                return Ok(());
             }
+
+            // If not filled completely - put it into corresponding bucket
+            let new_buckets = self.get_buckets_mut(order.action);
+            let bucket = new_buckets
+                .entry(order.price)
+                .or_insert_with(|| OrdersBucketNaive::new(order.price));
+            bucket.put(&order);
+            
+            // Update the order in the map
+            self.order_id_map.insert(order.order_id, order);
 
             Ok(())
         } else {
@@ -618,3 +614,4 @@ impl<'a> OrderBook<'a> for OrderBookNaiveImpl {
         // No-op for naive implementation
     }
 }
+

--- a/orderbook/src/naive_impl.rs
+++ b/orderbook/src/naive_impl.rs
@@ -453,21 +453,21 @@ impl<'a> OrderBook<'a> for OrderBookNaiveImpl {
 
             order.price = cmd.price;
             cmd.action = order.action;
-
+            cmd.uid = order.uid;
+            cmd.order_id = order.order_id;
+            
             // Try matching after price change
             let total_filled = self.try_match(cmd, order.filled);
-            order.filled = total_filled;
+            order.filled = total_filled;        
 
             // Insert into new bucket only if partially filled or not filled at all
             if order.size > order.filled {
-                let new_buckets = self.get_buckets_mut(order.action);
-                let bucket = new_buckets
-                    .entry(order.price)
-                    .or_insert_with(|| OrdersBucketNaive::new(order.price));
+                let new_buckets = if order.action == OrderAction::Ask { &mut self.ask_buckets } else { &mut self.bid_buckets };
+                let bucket = new_buckets.entry(order.price).or_insert_with(|| OrdersBucketNaive::new(order.price));
                 bucket.put(&order);
                 self.order_id_map.insert(order.order_id, order);
             }
-
+            
             Ok(())
         } else {
             Err(OrderBookError::UnknownOrderId)

--- a/orderbook/src/naive_impl.rs
+++ b/orderbook/src/naive_impl.rs
@@ -420,7 +420,7 @@ impl<'a> OrderBook<'a> for OrderBookNaiveImpl {
 
     fn move_order(&mut self, cmd: &mut OrderCommand) -> Result<(), OrderBookError> {
         let order = self.order_id_map.get(&cmd.order_id).cloned();
-        
+
         if let Some(mut order) = order {
             if order.uid != cmd.uid {
                 return Err(OrderBookError::UnknownOrderId);
@@ -445,7 +445,7 @@ impl<'a> OrderBook<'a> for OrderBookNaiveImpl {
 
             // Update order price
             order.price = cmd.price;
-            
+
             // Fill action field for events handling
             cmd.action = order.action;
 
@@ -467,7 +467,7 @@ impl<'a> OrderBook<'a> for OrderBookNaiveImpl {
                 .entry(order.price)
                 .or_insert_with(|| OrdersBucketNaive::new(order.price));
             bucket.put(&order);
-            
+
             // Update the order in the map
             self.order_id_map.insert(order.order_id, order);
 
@@ -614,4 +614,3 @@ impl<'a> OrderBook<'a> for OrderBookNaiveImpl {
         // No-op for naive implementation
     }
 }
-

--- a/orderbook/src/naive_impl.rs
+++ b/orderbook/src/naive_impl.rs
@@ -459,16 +459,22 @@ impl<'a> OrderBook<'a> for OrderBookNaiveImpl {
 
             // Try matching after price change
             let total_filled = self.try_match(cmd, order.filled);
-            order.filled = total_filled;        
+            order.filled = total_filled;
 
             // Insert into new bucket only if partially filled or not filled at all
             if order.size > order.filled {
-                let new_buckets = if order.action == OrderAction::Ask { &mut self.ask_buckets } else { &mut self.bid_buckets };
-                let bucket = new_buckets.entry(order.price).or_insert_with(|| OrdersBucketNaive::new(order.price));
+                let new_buckets = if order.action == OrderAction::Ask {
+                    &mut self.ask_buckets
+                } else {
+                    &mut self.bid_buckets
+                };
+                let bucket = new_buckets
+                    .entry(order.price)
+                    .or_insert_with(|| OrdersBucketNaive::new(order.price));
                 bucket.put(&order);
                 self.order_id_map.insert(order.order_id, order);
             }
-            
+
             Ok(())
         } else {
             Err(OrderBookError::UnknownOrderId)

--- a/orderbook/tests/orderbook.rs
+++ b/orderbook/tests/orderbook.rs
@@ -1,4 +1,4 @@
-use common::model::enums::{OrderAction, OrderType, MatcherEventType};
+use common::model::enums::{MatcherEventType, OrderAction, OrderType};
 use common::model::symbol_specification::TestConstants;
 use orderbook::naive_impl::OrderBookNaiveImpl;
 use orderbook::{OrderBook, OrderCommand};
@@ -77,17 +77,18 @@ fn test_move_order() {
     assert_eq!(order_book.get_order_by_id(1).unwrap().price(), 51000);
 }
 
-
 #[test]
 fn test_move_order_into_match_naive() {
     let mut order_book = create_order_book();
 
     // 1. Place a BID order for 10 shares at price 49900.
-    let mut bid_cmd = OrderCommand::new_order(OrderType::Gtc, 1, 200, 49900, 0, 10, OrderAction::Bid);
+    let mut bid_cmd =
+        OrderCommand::new_order(OrderType::Gtc, 1, 200, 49900, 0, 10, OrderAction::Bid);
     order_book.new_order(&mut bid_cmd).unwrap();
 
     // 2. Place an ASK order for 10 shares at price 50000.
-    let mut ask_cmd = OrderCommand::new_order(OrderType::Gtc, 2, 100, 50000, 0, 10, OrderAction::Ask);
+    let mut ask_cmd =
+        OrderCommand::new_order(OrderType::Gtc, 2, 100, 50000, 0, 10, OrderAction::Ask);
     order_book.new_order(&mut ask_cmd).unwrap();
 
     // Verify initial state.
@@ -97,7 +98,6 @@ fn test_move_order_into_match_naive() {
     // 3. Move the ASK order to a marketable price of 49800 (below the BID).
     let mut move_cmd = OrderCommand::move_order(2, 100, 49800);
     order_book.move_order(&mut move_cmd).unwrap();
-
 
     // The book should be empty because the orders matched.
     assert_eq!(order_book.get_total_orders_volume(OrderAction::Bid), 0);

--- a/orderbook/tests/orderbook.rs
+++ b/orderbook/tests/orderbook.rs
@@ -1,4 +1,4 @@
-use common::model::enums::{MatcherEventType, OrderAction, OrderType};
+use common::model::enums::{OrderAction, OrderType, MatcherEventType};
 use common::model::symbol_specification::TestConstants;
 use orderbook::naive_impl::OrderBookNaiveImpl;
 use orderbook::{OrderBook, OrderCommand};
@@ -77,6 +77,43 @@ fn test_move_order() {
     assert_eq!(order_book.get_order_by_id(1).unwrap().price(), 51000);
 }
 
+
+#[test]
+fn test_move_order_into_match_naive() {
+    let mut order_book = create_order_book();
+
+    // 1. Place a BID order for 10 shares at price 49900.
+    let mut bid_cmd = OrderCommand::new_order(OrderType::Gtc, 1, 200, 49900, 0, 10, OrderAction::Bid);
+    order_book.new_order(&mut bid_cmd).unwrap();
+
+    // 2. Place an ASK order for 10 shares at price 50000.
+    let mut ask_cmd = OrderCommand::new_order(OrderType::Gtc, 2, 100, 50000, 0, 10, OrderAction::Ask);
+    order_book.new_order(&mut ask_cmd).unwrap();
+
+    // Verify initial state.
+    assert_eq!(order_book.get_total_orders_volume(OrderAction::Bid), 10);
+    assert_eq!(order_book.get_total_orders_volume(OrderAction::Ask), 10);
+
+    // 3. Move the ASK order to a marketable price of 49800 (below the BID).
+    let mut move_cmd = OrderCommand::move_order(2, 100, 49800);
+    order_book.move_order(&mut move_cmd).unwrap();
+
+
+    // The book should be empty because the orders matched.
+    assert_eq!(order_book.get_total_orders_volume(OrderAction::Bid), 0);
+    assert_eq!(order_book.get_total_orders_volume(OrderAction::Ask), 0);
+    assert!(order_book.get_order_by_id(1).is_none());
+    assert!(order_book.get_order_by_id(2).is_none());
+
+    // Verify trade event generation.
+    let mut events = Vec::new();
+    let mut current_event = move_cmd.matcher_event;
+    while let Some(event) = current_event {
+        events.push(event.as_ref().event_type);
+        current_event = event.next_event;
+    }
+    assert!(events.contains(&MatcherEventType::Trade));
+}
 #[test]
 fn test_simple_matching() {
     let mut order_book = create_order_book();


### PR DESCRIPTION
- The move_order function in naive_impl.rs has been rewritten to follow the correct remove -> match -> insert sequence.
- An order being moved is now correctly treated as a taker order at its new price.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved order movement logic to maintain correct order identity and size during moves.
  * Enhanced handling of empty order buckets by removing them based on total volume.

* **Tests**
  * Added a test verifying that moving an order to a matching price triggers a trade and removes orders correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->