### PR TITLE
fix: fixed the volume update logic in try_match_instantly in direct_impl.rs

### DIFF
--- a/orderbook/src/direct_impl.rs
+++ b/orderbook/src/direct_impl.rs
@@ -232,6 +232,16 @@ impl OrderBookDirectImpl {
                 if maker_filled {
                     self.remove_order(maker_key);
                 }
+                else {
+                    let buckets = if maker_action == OrderAction::Ask {
+                        &mut self.ask_price_buckets
+                    } else {
+                        &mut self.bid_price_buckets
+                    };
+                    if let Some(bucket) = buckets.get_mut(&maker_order_price) {
+                        bucket.volume -= trade_size;
+                    }
+                }
             }
 
             maker_key_opt = maker_order_prev;

--- a/orderbook/src/direct_impl.rs
+++ b/orderbook/src/direct_impl.rs
@@ -196,19 +196,22 @@ impl OrderBookDirectImpl {
                 remaining_size -= trade_size;
                 filled += trade_size;
 
-                let buckets = if maker_action == OrderAction::Ask {
-                    &mut self.ask_price_buckets
-                } else {
-                    &mut self.bid_price_buckets
-                };
-                if let Some(bucket) = buckets.get_mut(&maker_order_price) {
-                    bucket.volume -= trade_size;
-                }
-
                 let maker_order_mut = &mut self.orders[maker_key];
                 maker_order_mut.filled += trade_size;
 
                 let maker_filled = maker_order_mut.filled == maker_order_mut.size;
+
+                if !maker_filled {
+                    // Only subtract from volume if not going to remove order
+                    let buckets = if cmd.action() == OrderAction::Ask {
+                        &mut self.bid_price_buckets
+                    } else {
+                        &mut self.ask_price_buckets
+                    };
+                    if let Some(bucket) = buckets.get_mut(&maker_order_mut.price) {
+                        bucket.volume -= trade_size;
+                    }
+                }
 
                 let trade_event = MatcherTradeEvent {
                     event_type: MatcherEventType::Trade,
@@ -231,15 +234,6 @@ impl OrderBookDirectImpl {
 
                 if maker_filled {
                     self.remove_order(maker_key);
-                } else {
-                    let buckets = if maker_action == OrderAction::Ask {
-                        &mut self.ask_price_buckets
-                    } else {
-                        &mut self.bid_price_buckets
-                    };
-                    if let Some(bucket) = buckets.get_mut(&maker_order_price) {
-                        bucket.volume -= trade_size;
-                    }
                 }
             }
 

--- a/orderbook/src/direct_impl.rs
+++ b/orderbook/src/direct_impl.rs
@@ -196,14 +196,14 @@ impl OrderBookDirectImpl {
                 remaining_size -= trade_size;
                 filled += trade_size;
 
-            let buckets = if maker_action == OrderAction::Ask {
-                &mut self.ask_price_buckets
-            } else {
-                &mut self.bid_price_buckets
-            };
-            if let Some(bucket) = buckets.get_mut(&maker_order_price) {
-                bucket.volume -= trade_size;
-            }
+                let buckets = if maker_action == OrderAction::Ask {
+                    &mut self.ask_price_buckets
+                } else {
+                    &mut self.bid_price_buckets
+                };
+                if let Some(bucket) = buckets.get_mut(&maker_order_price) {
+                    bucket.volume -= trade_size;
+                }
 
                 let maker_order_mut = &mut self.orders[maker_key];
                 maker_order_mut.filled += trade_size;
@@ -231,8 +231,7 @@ impl OrderBookDirectImpl {
 
                 if maker_filled {
                     self.remove_order(maker_key);
-                }
-                else {
+                } else {
                     let buckets = if maker_action == OrderAction::Ask {
                         &mut self.ask_price_buckets
                     } else {

--- a/orderbook/src/direct_impl.rs
+++ b/orderbook/src/direct_impl.rs
@@ -169,6 +169,7 @@ impl OrderBookDirectImpl {
             let maker_order_size;
             let maker_order_filled;
             let maker_order_prev;
+            let maker_action;
 
             {
                 let maker_order = &self.orders[maker_key];
@@ -176,6 +177,7 @@ impl OrderBookDirectImpl {
                 maker_order_size = maker_order.size;
                 maker_order_filled = maker_order.filled;
                 maker_order_prev = maker_order.prev;
+                maker_action = maker_order.action;
             }
 
             let can_match = if is_bid_action {
@@ -193,6 +195,15 @@ impl OrderBookDirectImpl {
             if trade_size > 0 {
                 remaining_size -= trade_size;
                 filled += trade_size;
+
+            let buckets = if maker_action == OrderAction::Ask {
+                &mut self.ask_price_buckets
+            } else {
+                &mut self.bid_price_buckets
+            };
+            if let Some(bucket) = buckets.get_mut(&maker_order_price) {
+                bucket.volume -= trade_size;
+            }
 
                 let maker_order_mut = &mut self.orders[maker_key];
                 maker_order_mut.filled += trade_size;

--- a/orderbook/src/direct_impl.rs
+++ b/orderbook/src/direct_impl.rs
@@ -169,7 +169,7 @@ impl OrderBookDirectImpl {
             let maker_order_size;
             let maker_order_filled;
             let maker_order_prev;
-            let maker_action;
+            let _maker_action;
 
             {
                 let maker_order = &self.orders[maker_key];
@@ -177,7 +177,7 @@ impl OrderBookDirectImpl {
                 maker_order_size = maker_order.size;
                 maker_order_filled = maker_order.filled;
                 maker_order_prev = maker_order.prev;
-                maker_action = maker_order.action;
+                _maker_action = maker_order.action;
             }
 
             let can_match = if is_bid_action {

--- a/orderbook/tests/orderbook.rs
+++ b/orderbook/tests/orderbook.rs
@@ -2,9 +2,13 @@ use common::model::enums::{MatcherEventType, OrderAction, OrderType};
 use common::model::symbol_specification::TestConstants;
 use orderbook::naive_impl::OrderBookNaiveImpl;
 use orderbook::{OrderBook, OrderCommand};
-
+use orderbook::direct_impl::OrderBookDirectImpl;
 fn create_order_book() -> OrderBookNaiveImpl {
     OrderBookNaiveImpl::new(TestConstants::symbol_spec_eth_xbt())
+}
+
+fn create_order_book_direct() -> OrderBookDirectImpl {
+    OrderBookDirectImpl::new(TestConstants::symbol_spec_eth_xbt())
 }
 
 #[test]
@@ -126,6 +130,36 @@ fn test_simple_matching() {
     assert_eq!(order_book.get_orders_num(OrderAction::Ask), 1);
     assert_eq!(order_book.get_orders_num(OrderAction::Bid), 0);
     assert_eq!(order_book.get_order_by_id(1).unwrap().filled(), 5);
+}
+
+#[test]
+fn test_partial_match_updates_bucket_volume() {
+    let mut order_book = create_order_book_direct();
+
+    // Place a large BID order (the maker). Size 100 at price 50000.
+    let mut maker_cmd = OrderCommand::new_order(OrderType::Gtc, 1, 100, 50000, 0, 100, OrderAction::Bid);
+    order_book.new_order(&mut maker_cmd).unwrap();
+
+    assert_eq!(order_book.get_total_orders_volume(OrderAction::Bid), 100);
+
+    let maker_order = order_book.get_order_by_id(1).unwrap();
+    assert_eq!(maker_order.size(), 100);
+    assert_eq!(maker_order.filled(), 0);
+
+    // Place a smaller ASK order (the taker) at a marketable price. Size 30.
+    let mut taker_cmd = OrderCommand::new_order(OrderType::Gtc, 2, 200, 49900, 0, 30, OrderAction::Ask);
+    order_book.new_order(&mut taker_cmd).unwrap();
+
+    // The taker (ASK) order should be completely filled and gone.
+    assert_eq!(order_book.get_total_orders_volume(OrderAction::Ask), 0);
+    assert!(order_book.get_order_by_id(2).is_none());
+    
+    // The maker (BID) order should still be on the book, but partially filled.
+    let maker_order_after_trade = order_book.get_order_by_id(1).unwrap();
+    assert_eq!(maker_order_after_trade.size(), 100);
+    assert_eq!(maker_order_after_trade.filled(), 30, "Maker order should be filled by 30");
+
+    assert_eq!(order_book.get_total_orders_volume(OrderAction::Bid), 70, "Bucket volume must be updated after partial match");
 }
 
 #[test]

--- a/orderbook/tests/orderbook.rs
+++ b/orderbook/tests/orderbook.rs
@@ -1,8 +1,8 @@
 use common::model::enums::{MatcherEventType, OrderAction, OrderType};
 use common::model::symbol_specification::TestConstants;
+use orderbook::direct_impl::OrderBookDirectImpl;
 use orderbook::naive_impl::OrderBookNaiveImpl;
 use orderbook::{OrderBook, OrderCommand};
-use orderbook::direct_impl::OrderBookDirectImpl;
 fn create_order_book() -> OrderBookNaiveImpl {
     OrderBookNaiveImpl::new(TestConstants::symbol_spec_eth_xbt())
 }
@@ -137,7 +137,8 @@ fn test_partial_match_updates_bucket_volume() {
     let mut order_book = create_order_book_direct();
 
     // Place a large BID order (the maker). Size 100 at price 50000.
-    let mut maker_cmd = OrderCommand::new_order(OrderType::Gtc, 1, 100, 50000, 0, 100, OrderAction::Bid);
+    let mut maker_cmd =
+        OrderCommand::new_order(OrderType::Gtc, 1, 100, 50000, 0, 100, OrderAction::Bid);
     order_book.new_order(&mut maker_cmd).unwrap();
 
     assert_eq!(order_book.get_total_orders_volume(OrderAction::Bid), 100);
@@ -147,19 +148,28 @@ fn test_partial_match_updates_bucket_volume() {
     assert_eq!(maker_order.filled(), 0);
 
     // Place a smaller ASK order (the taker) at a marketable price. Size 30.
-    let mut taker_cmd = OrderCommand::new_order(OrderType::Gtc, 2, 200, 49900, 0, 30, OrderAction::Ask);
+    let mut taker_cmd =
+        OrderCommand::new_order(OrderType::Gtc, 2, 200, 49900, 0, 30, OrderAction::Ask);
     order_book.new_order(&mut taker_cmd).unwrap();
 
     // The taker (ASK) order should be completely filled and gone.
     assert_eq!(order_book.get_total_orders_volume(OrderAction::Ask), 0);
     assert!(order_book.get_order_by_id(2).is_none());
-    
+
     // The maker (BID) order should still be on the book, but partially filled.
     let maker_order_after_trade = order_book.get_order_by_id(1).unwrap();
     assert_eq!(maker_order_after_trade.size(), 100);
-    assert_eq!(maker_order_after_trade.filled(), 30, "Maker order should be filled by 30");
+    assert_eq!(
+        maker_order_after_trade.filled(),
+        30,
+        "Maker order should be filled by 30"
+    );
 
-    assert_eq!(order_book.get_total_orders_volume(OrderAction::Bid), 70, "Bucket volume must be updated after partial match");
+    assert_eq!(
+        order_book.get_total_orders_volume(OrderAction::Bid),
+        70,
+        "Bucket volume must be updated after partial match"
+    );
 }
 
 #[test]


### PR DESCRIPTION
`572e03f` - fixed no volume updation after partial filling on any side
`570f62d` - test: tests the try_match_instantly that has a volume update flaw before update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of order volume tracking in the order book during partial matches, ensuring price bucket volumes are updated correctly after each trade.

* **Tests**
  * Added a new test to verify that partial matches correctly update the remaining order volume and price bucket totals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->