### PR TITLE
fix: In direct_impl.rs, fixed to perform instant matching 

### DIFF
--- a/orderbook/src/direct_impl.rs
+++ b/orderbook/src/direct_impl.rs
@@ -637,7 +637,16 @@ impl<'a> OrderBook<'a> for OrderBookDirectImpl {
 
         order_to_move.price = cmd.price();
 
-        self.insert_order(order_to_move);
+        cmd.action = order_to_move.action;
+        cmd.size = order_to_move.size; 
+        
+        let total_filled = self.try_match_instantly(cmd, order_to_move.filled);
+        order_to_move.filled = total_filled;
+        
+        // If not fully filled, insert the remainder back onto the book.
+        if order_to_move.size > order_to_move.filled {
+            self.insert_order(order_to_move);
+        }
 
         Ok(())
     }

--- a/orderbook/src/direct_impl.rs
+++ b/orderbook/src/direct_impl.rs
@@ -638,11 +638,11 @@ impl<'a> OrderBook<'a> for OrderBookDirectImpl {
         order_to_move.price = cmd.price();
 
         cmd.action = order_to_move.action;
-        cmd.size = order_to_move.size; 
-        
+        cmd.size = order_to_move.size;
+
         let total_filled = self.try_match_instantly(cmd, order_to_move.filled);
         order_to_move.filled = total_filled;
-        
+
         // If not fully filled, insert the remainder back onto the book.
         if order_to_move.size > order_to_move.filled {
             self.insert_order(order_to_move);


### PR DESCRIPTION
- The move_order function in direct_impl.rs has been rewritten to follow the correct remove -> match -> insert sequence.
- An order being moved is now correctly treated as a taker order at its new price.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Orders that are moved within the order book now attempt to match immediately at their new price, potentially resulting in instant trades.

* **Bug Fixes**
  * Orders that are fully matched during a move are no longer reinserted into the order book.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->