### PR TITLE
feat: added missing state_hash and idiomatic state_hash definition

### DIFF
--- a/common/src/model/symbol_specification.rs
+++ b/common/src/model/symbol_specification.rs
@@ -1,5 +1,5 @@
 use super::enums::SymbolType;
-use borsh::{BorshDeserialize, BorshSerialize};
+use borsh::{BorshDeserialize, BorshSerialize, to_vec};
 use serde::{Deserialize, Serialize};
 use std::hash::{Hash, Hasher};
 
@@ -29,21 +29,13 @@ impl CoreSymbolSpecification {
     pub fn builder() -> CoreSymbolSpecificationBuilder {
         CoreSymbolSpecificationBuilder::default()
     }
+}
 
-    /// Calculate the state hash for this symbol specification
-    pub fn state_hash(&self) -> u64 {
-        let mut hasher = std::collections::hash_map::DefaultHasher::new();
-        self.symbol_id.hash(&mut hasher);
-        self.symbol_type.code().hash(&mut hasher);
-        self.base_currency.hash(&mut hasher);
-        self.quote_currency.hash(&mut hasher);
-        self.base_scale_k.hash(&mut hasher);
-        self.quote_scale_k.hash(&mut hasher);
-        self.taker_fee.hash(&mut hasher);
-        self.maker_fee.hash(&mut hasher);
-        self.margin_buy.hash(&mut hasher);
-        self.margin_sell.hash(&mut hasher);
-        hasher.finish()
+/// Calculate the state hash for this symbol specification
+impl Hash for CoreSymbolSpecification {
+    fn hash<H: Hasher> (&self, state: &mut H) {
+        let encoded = to_vec(self).unwrap();
+        state.write(&encoded);
     }
 }
 

--- a/common/src/model/symbol_specification.rs
+++ b/common/src/model/symbol_specification.rs
@@ -1,5 +1,5 @@
 use super::enums::SymbolType;
-use borsh::{BorshDeserialize, BorshSerialize, to_vec};
+use borsh::{to_vec, BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
 use std::hash::{Hash, Hasher};
 
@@ -33,7 +33,7 @@ impl CoreSymbolSpecification {
 
 /// Calculate the state hash for this symbol specification
 impl Hash for CoreSymbolSpecification {
-    fn hash<H: Hasher> (&self, state: &mut H) {
+    fn hash<H: Hasher>(&self, state: &mut H) {
         let encoded = to_vec(self).unwrap();
         state.write(&encoded);
     }

--- a/common/src/model/user_profile.rs
+++ b/common/src/model/user_profile.rs
@@ -1,7 +1,7 @@
 use crate::model::symbol_position_record::SymbolPositionRecord;
-use borsh::{BorshDeserialize, BorshSerialize};
+use borsh::{BorshDeserialize, BorshSerialize, to_vec};
 use hashbrown::HashMap;
-
+use std::hash::{Hash, Hasher};
 // TODO ...
 // positions: IntObjectHashMap<SymbolPositionRecord>
 // accounts: IntLongHashMap
@@ -24,6 +24,15 @@ impl UserProfile {
             positions: HashMap::new(),
             accounts: HashMap::new(),
         }
+    }
+}
+/// Implements a state hash for data integrity checks, similar to the Java version.
+/// It works by serializing the entire struct into bytes and then hashing those bytes.
+impl Hash for UserProfile {
+
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        let encoded = to_vec(self).unwrap();
+        state.write(&encoded);
     }
 }
 

--- a/common/src/model/user_profile.rs
+++ b/common/src/model/user_profile.rs
@@ -31,7 +31,7 @@ impl UserProfile {
 impl Hash for UserProfile {
 
     fn hash<H: Hasher>(&self, state: &mut H) {
-        let encoded = to_vec(self).unwrap();
+        let encoded = to_vec(self).expect("UserProfile serialization should never fail");
         state.write(&encoded);
     }
 }

--- a/common/src/model/user_profile.rs
+++ b/common/src/model/user_profile.rs
@@ -1,5 +1,5 @@
 use crate::model::symbol_position_record::SymbolPositionRecord;
-use borsh::{BorshDeserialize, BorshSerialize, to_vec};
+use borsh::{to_vec, BorshDeserialize, BorshSerialize};
 use hashbrown::HashMap;
 use std::hash::{Hash, Hasher};
 // TODO ...
@@ -29,7 +29,6 @@ impl UserProfile {
 /// Implements a state hash for data integrity checks, similar to the Java version.
 /// It works by serializing the entire struct into bytes and then hashing those bytes.
 impl Hash for UserProfile {
-
     fn hash<H: Hasher>(&self, state: &mut H) {
         let encoded = to_vec(self).expect("UserProfile serialization should never fail");
         state.write(&encoded);

--- a/orderbook/src/direct_impl.rs
+++ b/orderbook/src/direct_impl.rs
@@ -1379,23 +1379,19 @@ mod tests {
             let restored_l2 = restored.get_l2_market_data_snapshot(10);
             assert_eq!(
                 current_l2.ask_prices, restored_l2.ask_prices,
-                "Round {}",
-                round
+                "Round {round}"
             );
             assert_eq!(
                 current_l2.ask_volumes, restored_l2.ask_volumes,
-                "Round {}",
-                round
+                "Round {round}"
             );
             assert_eq!(
                 current_l2.bid_prices, restored_l2.bid_prices,
-                "Round {}",
-                round
+                "Round {round}"
             );
             assert_eq!(
                 current_l2.bid_volumes, restored_l2.bid_volumes,
-                "Round {}",
-                round
+                "Round {round}"
             );
 
             restored.validate_internal_state();

--- a/orderbook/tests/symbol_specification.rs
+++ b/orderbook/tests/symbol_specification.rs
@@ -84,15 +84,15 @@ fn should_work_with_different_symbol_types() {
     assert_eq!(futures_book.get_symbol_spec().symbol_id, 5991);
 }
 
-use std::hash::{Hash, Hasher};
 use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
 #[test]
 fn should_calculate_state_hash() {
     let symbol_spec = TestConstants::symbol_spec_eth_xbt();
     let mut hasher1 = DefaultHasher::new();
     symbol_spec.hash(&mut hasher1);
     let hash1 = hasher1.finish();
-    
+
     // Same spec should produce same hash
     let symbol_spec2 = TestConstants::symbol_spec_eth_xbt();
     let mut hasher2 = DefaultHasher::new();

--- a/orderbook/tests/symbol_specification.rs
+++ b/orderbook/tests/symbol_specification.rs
@@ -84,19 +84,27 @@ fn should_work_with_different_symbol_types() {
     assert_eq!(futures_book.get_symbol_spec().symbol_id, 5991);
 }
 
+use std::hash::{Hash, Hasher};
+use std::collections::hash_map::DefaultHasher;
 #[test]
 fn should_calculate_state_hash() {
     let symbol_spec = TestConstants::symbol_spec_eth_xbt();
-    let hash1 = symbol_spec.state_hash();
-
+    let mut hasher1 = DefaultHasher::new();
+    symbol_spec.hash(&mut hasher1);
+    let hash1 = hasher1.finish();
+    
     // Same spec should produce same hash
     let symbol_spec2 = TestConstants::symbol_spec_eth_xbt();
-    let hash2 = symbol_spec2.state_hash();
+    let mut hasher2 = DefaultHasher::new();
+    symbol_spec2.hash(&mut hasher2);
+    let hash2 = hasher2.finish();
     assert_eq!(hash1, hash2);
 
     // Different spec should produce different hash
     let symbol_spec3 = TestConstants::symbol_spec_eur_usd();
-    let hash3 = symbol_spec3.state_hash();
+    let mut hasher3 = DefaultHasher::new();
+    symbol_spec3.hash(&mut hasher3);
+    let hash3 = hasher3.finish();
     assert_ne!(hash1, hash3);
 }
 


### PR DESCRIPTION
-  Implement the standard Rust `Hash` trait for UserProfile. The Java version has a `stateHash()` method used for data integrity checks. This is crucial for verifying that state is consistent across the system. The most robust way is to use the existing `BorshSerialize` implementation to get a byte representation and then hash it.
- `symbol_specification.rs` uses a manual `state_hash()` method. This is an inconsistency that could lead to bugs later if a field is added to the struct but not the manual hash function. Hence, made it idiomatic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for generating consistent hash values for user profiles and symbol specifications, improving data integrity verification.

* **Bug Fixes**
  * Updated tests to use the new hashing approach for symbol specifications, ensuring accurate hash comparisons.

* **Chores**
  * Improved assertion message formatting in market data snapshot tests for clearer test output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->