### PR TITLE
fix: remove --deny warnings to supress warnings in the audit

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,2 @@
+[advisories]
+ignore = ["RUSTSEC-2024-0436"]  # paste crate v1.0.15 - unmaintained

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,4 +74,4 @@ jobs:
       - name: Install cargo-audit
         run: cargo install cargo-audit
       - name: Run security audit
-        run: cargo audit
+        run: cargo audit --deny warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,4 +74,4 @@ jobs:
       - name: Install cargo-audit
         run: cargo install cargo-audit
       - name: Run security audit
-        run: cargo audit --deny warnings
+        run: cargo audit

--- a/common/src/api/mod.rs
+++ b/common/src/api/mod.rs
@@ -72,4 +72,4 @@ impl ApiCommand for ApiReduceOrder {
     fn into_order_command(self) -> OrderCommand {
         OrderCommand::reduce(self.order_id, self.uid, self.reduce_size)
     }
-} 
+}

--- a/common/src/cmd/mod.rs
+++ b/common/src/cmd/mod.rs
@@ -1,4 +1,4 @@
-use crate::model::enums::{OrderAction, OrderType, MatcherEventType};
+use crate::model::enums::{MatcherEventType, OrderAction, OrderType};
 use crate::model::order::OrderTrait;
 use borsh::{BorshDeserialize, BorshSerialize};
 
@@ -76,7 +76,7 @@ impl OrderCommand {
             price: 0,
             reserve_bid_price: 0,
             size: 0,
-            action: OrderAction::Ask, // Will be ignored
+            action: OrderAction::Ask,   // Will be ignored
             order_type: OrderType::Gtc, // Will be ignored
             user_cookie: 0,
             timestamp: 0,
@@ -93,7 +93,7 @@ impl OrderCommand {
             price: 0,
             reserve_bid_price: 0,
             size,
-            action: OrderAction::Ask, // Will be ignored
+            action: OrderAction::Ask,   // Will be ignored
             order_type: OrderType::Gtc, // Will be ignored
             user_cookie: 0,
             timestamp: 0,
@@ -110,7 +110,7 @@ impl OrderCommand {
             price,
             reserve_bid_price: 0,
             size: 0,
-            action: OrderAction::Ask, // Will be ignored
+            action: OrderAction::Ask,   // Will be ignored
             order_type: OrderType::Gtc, // Will be ignored
             user_cookie: 0,
             timestamp: 0,
@@ -223,4 +223,3 @@ impl Default for MatcherTradeEvent {
         }
     }
 }
-

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1,3 +1,3 @@
-pub mod model;
-pub mod cmd;
 pub mod api;
+pub mod cmd;
+pub mod model;

--- a/common/src/model/core_arithmetic.rs
+++ b/common/src/model/core_arithmetic.rs
@@ -16,17 +16,29 @@ impl CoreArithmetic {
     }
 
     /// Calculate the amount for a BID order including the taker fee.
-    pub fn calculate_amount_bid_taker_fee(size: i64, price: i64, spec: &CoreSymbolSpecification) -> i64 {
+    pub fn calculate_amount_bid_taker_fee(
+        size: i64,
+        price: i64,
+        spec: &CoreSymbolSpecification,
+    ) -> i64 {
         size * (price * spec.quote_scale_k + spec.taker_fee)
     }
 
     /// Calculate the correction amount to be released for a BID order when a maker is involved.
-    pub fn calculate_amount_bid_release_corr_maker(size: i64, price_diff: i64, spec: &CoreSymbolSpecification) -> i64 {
+    pub fn calculate_amount_bid_release_corr_maker(
+        size: i64,
+        price_diff: i64,
+        spec: &CoreSymbolSpecification,
+    ) -> i64 {
         size * (price_diff * spec.quote_scale_k + (spec.taker_fee - spec.maker_fee))
     }
 
     /// Calculate the required budget for a BID order including the taker fee.
-    pub fn calculate_amount_bid_taker_fee_for_budget(size: i64, budget_in_steps: i64, spec: &CoreSymbolSpecification) -> i64 {
+    pub fn calculate_amount_bid_taker_fee_for_budget(
+        size: i64,
+        budget_in_steps: i64,
+        spec: &CoreSymbolSpecification,
+    ) -> i64 {
         budget_in_steps * spec.quote_scale_k + size * spec.taker_fee
     }
 }

--- a/common/src/model/enums.rs
+++ b/common/src/model/enums.rs
@@ -48,10 +48,10 @@ pub enum OrderType {
     // Good till Cancel - equivalent to regular limit order
     Gtc = 0,
     // Immediate or Cancel - equivalent to strict-risk market order
-    Ioc = 1, // with price cap
+    Ioc = 1,       // with price cap
     IocBudget = 2, // with total amount cap
     // Fill or Kill - execute immediately completely or not at all
-    Fok = 3, // with price cap
+    Fok = 3,       // with price cap
     FokBudget = 4, // total amount cap
 }
 
@@ -79,22 +79,14 @@ impl SymbolType {
     pub fn code(&self) -> u8 {
         *self as u8
     }
-    
+
     pub fn of(code: u8) -> Result<Self, num_enum::TryFromPrimitiveError<Self>> {
         Self::try_from(code)
     }
 }
 
 #[derive(
-    Debug,
-    PartialEq,
-    Eq,
-    Clone,
-    Copy,
-    Serialize,
-    Deserialize,
-    BorshSerialize,
-    BorshDeserialize,
+    Debug, PartialEq, Eq, Clone, Copy, Serialize, Deserialize, BorshSerialize, BorshDeserialize,
 )]
 #[borsh(use_discriminant = true)]
 pub enum MatcherEventType {
@@ -148,4 +140,4 @@ impl PositionDirection {
             PositionDirection::Short => -1,
         }
     }
-} 
+}

--- a/common/src/model/l2_market_data.rs
+++ b/common/src/model/l2_market_data.rs
@@ -64,4 +64,4 @@ impl L2MarketData {
     pub fn total_order_book_volume_bid(&self) -> i64 {
         self.bid_volumes.iter().sum()
     }
-} 
+}

--- a/common/src/model/mod.rs
+++ b/common/src/model/mod.rs
@@ -1,7 +1,7 @@
-pub mod enums;
-pub mod order;
-pub mod l2_market_data;
-pub mod symbol_specification;
 pub mod core_arithmetic;
+pub mod enums;
+pub mod l2_market_data;
+pub mod order;
+pub mod symbol_position_record;
+pub mod symbol_specification;
 pub mod user_profile;
-pub mod symbol_position_record; 

--- a/common/src/model/order.rs
+++ b/common/src/model/order.rs
@@ -12,15 +12,7 @@ pub trait OrderTrait {
     fn reserve_bid_price(&self) -> i64;
 }
 
-#[derive(
-    Debug,
-    Clone,
-    Copy,
-    PartialEq,
-    Eq,
-    BorshSerialize,
-    BorshDeserialize,
-)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct Order {
     pub order_id: i64,
     pub price: i64,
@@ -57,4 +49,4 @@ impl OrderTrait for Order {
     fn reserve_bid_price(&self) -> i64 {
         self.reserve_bid_price
     }
-} 
+}

--- a/common/src/model/symbol_position_record.rs
+++ b/common/src/model/symbol_position_record.rs
@@ -1,5 +1,5 @@
-use borsh::{BorshDeserialize, BorshSerialize};
 use crate::model::enums::PositionDirection;
+use borsh::{BorshDeserialize, BorshSerialize};
 
 #[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
 pub struct SymbolPositionRecord {
@@ -12,4 +12,4 @@ pub struct SymbolPositionRecord {
     pub profit: i64,
     pub pending_sell_size: i64,
     pub pending_buy_size: i64,
-} 
+}

--- a/common/src/model/symbol_specification.rs
+++ b/common/src/model/symbol_specification.rs
@@ -1,6 +1,6 @@
+use super::enums::SymbolType;
 use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
-use super::enums::SymbolType;
 use std::hash::{Hash, Hasher};
 
 /// Core symbol specification that defines trading parameters for a symbol.
@@ -9,27 +9,27 @@ use std::hash::{Hash, Hasher};
 pub struct CoreSymbolSpecification {
     pub symbol_id: i32,
     pub symbol_type: SymbolType,
-    
+
     // Currency pair specification
-    pub base_currency: i32,   // base currency
-    pub quote_currency: i32,  // quote/counter currency (OR futures contract currency)
-    pub base_scale_k: i64,    // base currency amount multiplier (lot size in base currency units)
-    pub quote_scale_k: i64,   // quote currency amount multiplier (step size in quote currency units)
-    
+    pub base_currency: i32,  // base currency
+    pub quote_currency: i32, // quote/counter currency (OR futures contract currency)
+    pub base_scale_k: i64,   // base currency amount multiplier (lot size in base currency units)
+    pub quote_scale_k: i64,  // quote currency amount multiplier (step size in quote currency units)
+
     // Fees per lot in quote currency units
-    pub taker_fee: i64,       // taker fee (should be >= maker fee)
-    pub maker_fee: i64,       // maker fee
-    
+    pub taker_fee: i64, // taker fee (should be >= maker fee)
+    pub maker_fee: i64, // maker fee
+
     // Margin settings (for type=FUTURES_CONTRACT only)
-    pub margin_buy: i64,      // buy margin (quote currency)
-    pub margin_sell: i64,     // sell margin (quote currency)
+    pub margin_buy: i64,  // buy margin (quote currency)
+    pub margin_sell: i64, // sell margin (quote currency)
 }
 
 impl CoreSymbolSpecification {
     pub fn builder() -> CoreSymbolSpecificationBuilder {
         CoreSymbolSpecificationBuilder::default()
     }
-    
+
     /// Calculate the state hash for this symbol specification
     pub fn state_hash(&self) -> u64 {
         let mut hasher = std::collections::hash_map::DefaultHasher::new();
@@ -67,52 +67,52 @@ impl CoreSymbolSpecificationBuilder {
         self.symbol_id = Some(symbol_id);
         self
     }
-    
+
     pub fn symbol_type(mut self, symbol_type: SymbolType) -> Self {
         self.symbol_type = Some(symbol_type);
         self
     }
-    
+
     pub fn base_currency(mut self, base_currency: i32) -> Self {
         self.base_currency = Some(base_currency);
         self
     }
-    
+
     pub fn quote_currency(mut self, quote_currency: i32) -> Self {
         self.quote_currency = Some(quote_currency);
         self
     }
-    
+
     pub fn base_scale_k(mut self, base_scale_k: i64) -> Self {
         self.base_scale_k = Some(base_scale_k);
         self
     }
-    
+
     pub fn quote_scale_k(mut self, quote_scale_k: i64) -> Self {
         self.quote_scale_k = Some(quote_scale_k);
         self
     }
-    
+
     pub fn taker_fee(mut self, taker_fee: i64) -> Self {
         self.taker_fee = Some(taker_fee);
         self
     }
-    
+
     pub fn maker_fee(mut self, maker_fee: i64) -> Self {
         self.maker_fee = Some(maker_fee);
         self
     }
-    
+
     pub fn margin_buy(mut self, margin_buy: i64) -> Self {
         self.margin_buy = Some(margin_buy);
         self
     }
-    
+
     pub fn margin_sell(mut self, margin_sell: i64) -> Self {
         self.margin_sell = Some(margin_sell);
         self
     }
-    
+
     pub fn build(self) -> Result<CoreSymbolSpecification, &'static str> {
         Ok(CoreSymbolSpecification {
             symbol_id: self.symbol_id.ok_or("symbol_id is required")?,
@@ -136,13 +136,13 @@ impl TestConstants {
     pub const SYMBOL_MARGIN: i32 = 5991;
     pub const SYMBOL_EXCHANGE: i32 = 9269;
     pub const SYMBOL_EXCHANGE_FEE: i32 = 9340;
-    
+
     pub const CURRENCY_EUR: i32 = 978;
     pub const CURRENCY_USD: i32 = 840;
-    pub const CURRENCY_XBT: i32 = 3762;  // satoshi, 1E-8
-    pub const CURRENCY_ETH: i32 = 3928;  // szabo, 1E-6
-    pub const CURRENCY_LTC: i32 = 1005;  // litoshi, 1E-8
-    
+    pub const CURRENCY_XBT: i32 = 3762; // satoshi, 1E-8
+    pub const CURRENCY_ETH: i32 = 3928; // szabo, 1E-6
+    pub const CURRENCY_LTC: i32 = 1005; // litoshi, 1E-8
+
     /// EUR/USD futures contract for margin trading
     pub fn symbol_spec_eur_usd() -> CoreSymbolSpecification {
         CoreSymbolSpecification::builder()
@@ -159,34 +159,34 @@ impl TestConstants {
             .build()
             .unwrap()
     }
-    
+
     /// ETH/XBT currency exchange pair (no fees)
     pub fn symbol_spec_eth_xbt() -> CoreSymbolSpecification {
         CoreSymbolSpecification::builder()
             .symbol_id(Self::SYMBOL_EXCHANGE)
             .symbol_type(SymbolType::CurrencyExchangePair)
-            .base_currency(Self::CURRENCY_ETH)    // base = szabo
-            .quote_currency(Self::CURRENCY_XBT)   // quote = satoshi  
-            .base_scale_k(100_000)                // 1 lot = 100K szabo (0.1 ETH)
-            .quote_scale_k(10)                    // 1 step = 10 satoshi
+            .base_currency(Self::CURRENCY_ETH) // base = szabo
+            .quote_currency(Self::CURRENCY_XBT) // quote = satoshi
+            .base_scale_k(100_000) // 1 lot = 100K szabo (0.1 ETH)
+            .quote_scale_k(10) // 1 step = 10 satoshi
             .taker_fee(0)
             .maker_fee(0)
             .build()
             .unwrap()
     }
-    
+
     /// XBT/LTC currency exchange pair (with fees)
     pub fn symbol_spec_fee_xbt_ltc() -> CoreSymbolSpecification {
         CoreSymbolSpecification::builder()
             .symbol_id(Self::SYMBOL_EXCHANGE_FEE)
             .symbol_type(SymbolType::CurrencyExchangePair)
-            .base_currency(Self::CURRENCY_XBT)    // base = satoshi
-            .quote_currency(Self::CURRENCY_LTC)   // quote = litoshi
-            .base_scale_k(1_000_000)              // 1 lot = 1M satoshi (0.01 BTC)
-            .quote_scale_k(10_000)                // 1 step = 10K litoshi
-            .taker_fee(1900)                      // taker fee 1900 litoshi per 1 lot
-            .maker_fee(700)                       // maker fee 700 litoshi per 1 lot
+            .base_currency(Self::CURRENCY_XBT) // base = satoshi
+            .quote_currency(Self::CURRENCY_LTC) // quote = litoshi
+            .base_scale_k(1_000_000) // 1 lot = 1M satoshi (0.01 BTC)
+            .quote_scale_k(10_000) // 1 step = 10K litoshi
+            .taker_fee(1900) // taker fee 1900 litoshi per 1 lot
+            .maker_fee(700) // maker fee 700 litoshi per 1 lot
             .build()
             .unwrap()
     }
-} 
+}

--- a/common/src/model/user_profile.rs
+++ b/common/src/model/user_profile.rs
@@ -31,4 +31,4 @@ impl UserProfile {
 pub enum UserStatus {
     Active,
     Suspended,
-} 
+}

--- a/orderbook/src/direct_impl.rs
+++ b/orderbook/src/direct_impl.rs
@@ -1,13 +1,13 @@
-use common::model::order::{OrderTrait, Order};
-use common::model::enums::{OrderAction, OrderType, MatcherEventType, SymbolType};
-use common::model::symbol_specification::CoreSymbolSpecification;
-use crate::{OrderBook, OrderBookImplType, OrderCommand, OrderBookError, MatcherTradeEvent};
 use crate::events::EventHelper;
-use tracing::warn;
+use crate::{MatcherTradeEvent, OrderBook, OrderBookError, OrderBookImplType, OrderCommand};
 use blart::TreeMap;
-use slab::Slab;
-use hashbrown::HashMap;
 use borsh::{BorshDeserialize, BorshSerialize};
+use common::model::enums::{MatcherEventType, OrderAction, OrderType, SymbolType};
+use common::model::order::{Order, OrderTrait};
+use common::model::symbol_specification::CoreSymbolSpecification;
+use hashbrown::HashMap;
+use slab::Slab;
+use tracing::warn;
 
 pub struct OrderBookDirectImpl {
     ask_price_buckets: TreeMap<i64, Bucket>,
@@ -50,14 +50,14 @@ impl OrderBookDirectImpl {
         let mut writer = Vec::new();
         self.get_implementation_type().serialize(&mut writer)?;
         self.symbol_spec.serialize(&mut writer)?;
-        
+
         let num_orders = self.orders.len() as u32;
         num_orders.serialize(&mut writer)?;
 
         for (_, order) in self.orders.iter() {
             order.serialize(&mut writer)?;
         }
-        
+
         Ok(writer)
     }
 
@@ -122,18 +122,24 @@ impl OrderBookDirectImpl {
         };
 
         while let Some(key) = next_key {
-            if size == 0 { break; }
+            if size == 0 {
+                break;
+            }
             let order = &self.orders[key];
             let available_size = order.size - order.filled;
             let trade_size = std::cmp::min(size, available_size);
-            
+
             budget += trade_size * order.price;
             size -= trade_size;
 
             next_key = order.prev;
         }
 
-        if size == 0 { budget } else { i64::MAX }
+        if size == 0 {
+            budget
+        } else {
+            i64::MAX
+        }
     }
 
     fn try_match_instantly(&mut self, cmd: &mut OrderCommand, filled: i64) -> i64 {
@@ -192,7 +198,7 @@ impl OrderBookDirectImpl {
                 maker_order_mut.filled += trade_size;
 
                 let maker_filled = maker_order_mut.filled == maker_order_mut.size;
-                
+
                 let trade_event = MatcherTradeEvent {
                     event_type: MatcherEventType::Trade,
                     section: 0, // TODO
@@ -202,7 +208,11 @@ impl OrderBookDirectImpl {
                     matched_order_completed: maker_filled,
                     price: maker_order_mut.price,
                     size: trade_size,
-                    bidder_hold_price: if cmd.action() == OrderAction::Ask { cmd.reserve_bid_price() } else { maker_order_mut.reserve_bid_price },
+                    bidder_hold_price: if cmd.action() == OrderAction::Ask {
+                        cmd.reserve_bid_price()
+                    } else {
+                        maker_order_mut.reserve_bid_price
+                    },
                     ..MatcherTradeEvent::default()
                 };
 
@@ -244,7 +254,8 @@ impl OrderBookDirectImpl {
                 if self.best_ask_order == Some(order_key) {
                     self.best_ask_order = next_key;
                 }
-            } else { // Bid
+            } else {
+                // Bid
                 if self.best_bid_order == Some(order_key) {
                     self.best_bid_order = next_key;
                 }
@@ -272,7 +283,7 @@ impl OrderBookDirectImpl {
                             bucket.tail = None; // Successor is in another bucket, this bucket is now empty of its tail.
                         }
                     } else {
-                         bucket.tail = None;
+                        bucket.tail = None;
                     }
                 }
 
@@ -285,7 +296,11 @@ impl OrderBookDirectImpl {
 
     fn insert_order(&mut self, mut order: DirectOrder) {
         let is_ask = order.action == OrderAction::Ask;
-        let buckets = if is_ask { &mut self.ask_price_buckets } else { &mut self.bid_price_buckets };
+        let buckets = if is_ask {
+            &mut self.ask_price_buckets
+        } else {
+            &mut self.bid_price_buckets
+        };
         let price = order.price;
 
         let (predecessor, successor) = if let Some(bucket) = buckets.get_mut(&price) {
@@ -296,24 +311,35 @@ impl OrderBookDirectImpl {
         } else {
             // New price level, find successor bucket.
             let successor_bucket_tail = if is_ask {
-                buckets.range((std::ops::Bound::Excluded(price), std::ops::Bound::Unbounded))
-                    .next().map(|(_, b)| b.tail.unwrap())
+                buckets
+                    .range((std::ops::Bound::Excluded(price), std::ops::Bound::Unbounded))
+                    .next()
+                    .map(|(_, b)| b.tail.unwrap())
             } else {
-                buckets.range((std::ops::Bound::Unbounded, std::ops::Bound::Excluded(price)))
-                    .next_back().map(|(_, b)| b.tail.unwrap())
+                buckets
+                    .range((std::ops::Bound::Unbounded, std::ops::Bound::Excluded(price)))
+                    .next_back()
+                    .map(|(_, b)| b.tail.unwrap())
             };
-            
+
             if let Some(succ_key) = successor_bucket_tail {
                 (self.orders[succ_key].prev, Some(succ_key))
             } else {
                 // New best price level.
-                (if is_ask { self.best_ask_order } else { self.best_bid_order }, None)
+                (
+                    if is_ask {
+                        self.best_ask_order
+                    } else {
+                        self.best_bid_order
+                    },
+                    None,
+                )
             }
         };
 
         order.prev = predecessor;
         order.next = successor;
-        
+
         let new_order_key = self.orders.insert(order);
         let new_order_id = self.orders[new_order_key].order_id;
         self.order_id_index.insert(new_order_id, new_order_key);
@@ -327,16 +353,20 @@ impl OrderBookDirectImpl {
 
         // Update best order if necessary
         if successor.is_none() {
-             if is_ask { self.best_ask_order = Some(new_order_key); } else { self.best_bid_order = Some(new_order_key); }
+            if is_ask {
+                self.best_ask_order = Some(new_order_key);
+            } else {
+                self.best_bid_order = Some(new_order_key);
+            }
         }
-        
+
         // Update or create bucket
         let bucket = buckets.entry(price).or_insert_with(|| Bucket {
             volume: 0,
             num_orders: 0,
             tail: None,
         });
-        
+
         let new_order = &self.orders[new_order_key];
         bucket.volume += new_order.size - new_order.filled;
         bucket.num_orders += 1;
@@ -345,8 +375,16 @@ impl OrderBookDirectImpl {
 
     fn validate_chain(&self, action: OrderAction, orders_in_chain: &mut hashbrown::HashSet<i64>) {
         let is_ask = action == OrderAction::Ask;
-        let buckets = if is_ask { &self.ask_price_buckets } else { &self.bid_price_buckets };
-        let mut current_order_key = if is_ask { self.best_ask_order } else { self.best_bid_order };
+        let buckets = if is_ask {
+            &self.ask_price_buckets
+        } else {
+            &self.bid_price_buckets
+        };
+        let mut current_order_key = if is_ask {
+            self.best_ask_order
+        } else {
+            self.best_bid_order
+        };
 
         let mut last_price = -1i64;
         let mut orders_in_bucket = 0;
@@ -356,12 +394,18 @@ impl OrderBookDirectImpl {
         while let Some(order_key) = current_order_key {
             let order = &self.orders[order_key];
             assert_eq!(order.action, action, "Order has wrong action");
-            assert!(orders_in_chain.insert(order.order_id), "Duplicate order in chain");
+            assert!(
+                orders_in_chain.insert(order.order_id),
+                "Duplicate order in chain"
+            );
 
             if last_price != -1 && order.price != last_price {
                 // Moved to a new price bucket
                 let bucket = buckets.get(&last_price).unwrap();
-                assert_eq!(bucket.num_orders, orders_in_bucket, "Bucket order count mismatch");
+                assert_eq!(
+                    bucket.num_orders, orders_in_bucket,
+                    "Bucket order count mismatch"
+                );
                 assert_eq!(bucket.volume, volume_in_bucket, "Bucket volume mismatch");
                 orders_in_bucket = 0;
                 volume_in_bucket = 0;
@@ -369,7 +413,7 @@ impl OrderBookDirectImpl {
 
             orders_in_bucket += 1;
             volume_in_bucket += order.size - order.filled;
-            
+
             assert_eq!(order.next, prev_order_key, "Next pointer is incorrect");
 
             last_price = order.price;
@@ -379,8 +423,14 @@ impl OrderBookDirectImpl {
 
         if last_price != -1 {
             let bucket = buckets.get(&last_price).unwrap();
-            assert_eq!(bucket.num_orders, orders_in_bucket, "Last bucket order count mismatch");
-            assert_eq!(bucket.volume, volume_in_bucket, "Last bucket volume mismatch");
+            assert_eq!(
+                bucket.num_orders, orders_in_bucket,
+                "Last bucket order count mismatch"
+            );
+            assert_eq!(
+                bucket.volume, volume_in_bucket,
+                "Last bucket volume mismatch"
+            );
         }
     }
 }
@@ -577,10 +627,10 @@ impl<'a> OrderBook<'a> for OrderBookDirectImpl {
         }
 
         let mut order_to_move = self.orders[*order_key].clone();
-        
-        if self.symbol_spec.symbol_type == SymbolType::CurrencyExchangePair 
-            && order_to_move.action == OrderAction::Bid 
-            && cmd.price > order_to_move.reserve_bid_price 
+
+        if self.symbol_spec.symbol_type == SymbolType::CurrencyExchangePair
+            && order_to_move.action == OrderAction::Bid
+            && cmd.price > order_to_move.reserve_bid_price
         {
             return Err(OrderBookError::MoveFailedPriceOverRiskLimit);
         }
@@ -613,7 +663,8 @@ impl<'a> OrderBook<'a> for OrderBookDirectImpl {
     }
 
     fn get_order_by_id(&self, order_id: i64) -> Option<&dyn OrderTrait> {
-        self.order_id_index.get(&order_id)
+        self.order_id_index
+            .get(&order_id)
             .and_then(|&key| self.orders.get(key))
             .map(|order| order as &dyn OrderTrait)
     }
@@ -627,7 +678,10 @@ impl<'a> OrderBook<'a> for OrderBookDirectImpl {
             .collect()
     }
 
-    fn ask_orders_stream(&'a self, sorted: bool) -> Box<dyn Iterator<Item = &'a dyn OrderTrait> + 'a> {
+    fn ask_orders_stream(
+        &'a self,
+        sorted: bool,
+    ) -> Box<dyn Iterator<Item = &'a dyn OrderTrait> + 'a> {
         let bucket_iter: Box<dyn Iterator<Item = &'a Bucket> + 'a> = if sorted {
             Box::new(self.ask_price_buckets.values())
         } else {
@@ -641,7 +695,10 @@ impl<'a> OrderBook<'a> for OrderBookDirectImpl {
         })
     }
 
-    fn bid_orders_stream(&'a self, sorted: bool) -> Box<dyn Iterator<Item = &'a dyn OrderTrait> + 'a> {
+    fn bid_orders_stream(
+        &'a self,
+        sorted: bool,
+    ) -> Box<dyn Iterator<Item = &'a dyn OrderTrait> + 'a> {
         let bucket_iter: Box<dyn Iterator<Item = &'a Bucket> + 'a> = if sorted {
             Box::new(self.bid_price_buckets.values().rev())
         } else {
@@ -655,7 +712,10 @@ impl<'a> OrderBook<'a> for OrderBookDirectImpl {
         })
     }
 
-    fn get_l2_market_data_snapshot(&self, size: usize) -> common::model::l2_market_data::L2MarketData {
+    fn get_l2_market_data_snapshot(
+        &self,
+        size: usize,
+    ) -> common::model::l2_market_data::L2MarketData {
         let asks_size = self.get_total_ask_buckets(size);
         let bids_size = self.get_total_bid_buckets(size);
         let mut data = common::model::l2_market_data::L2MarketData::with_size(asks_size, bids_size);
@@ -664,7 +724,10 @@ impl<'a> OrderBook<'a> for OrderBookDirectImpl {
         data
     }
 
-    fn publish_l2_market_data_snapshot(&self, data: &mut common::model::l2_market_data::L2MarketData) {
+    fn publish_l2_market_data_snapshot(
+        &self,
+        data: &mut common::model::l2_market_data::L2MarketData,
+    ) {
         self.fill_asks(data.ask_prices.capacity(), data);
         self.fill_bids(data.bid_prices.capacity(), data);
     }
@@ -713,11 +776,19 @@ impl<'a> OrderBook<'a> for OrderBookDirectImpl {
         let mut orders_in_chain = hashbrown::HashSet::new();
         self.validate_chain(OrderAction::Ask, &mut orders_in_chain);
         self.validate_chain(OrderAction::Bid, &mut orders_in_chain);
-        
-        assert_eq!(self.order_id_index.len(), orders_in_chain.len(), "order_id_index size does not match chain size");
+
+        assert_eq!(
+            self.order_id_index.len(),
+            orders_in_chain.len(),
+            "order_id_index size does not match chain size"
+        );
 
         for key in self.order_id_index.keys() {
-            assert!(orders_in_chain.contains(key), "orderIdIndex contains an order not in a chain: {}", key);
+            assert!(
+                orders_in_chain.contains(key),
+                "orderIdIndex contains an order not in a chain: {}",
+                key
+            );
         }
     }
-} 
+}

--- a/orderbook/src/direct_impl.rs
+++ b/orderbook/src/direct_impl.rs
@@ -277,7 +277,7 @@ impl OrderBookDirectImpl {
                     // The order we removed was the tail of the bucket. The new tail is its successor in the global list.
                     // We only care if the successor is in the same bucket.
                     if let Some(n_key) = next_key {
-                        if self.orders.get(n_key).map_or(false, |p| p.price == price) {
+                        if self.orders.get(n_key).is_some_and(|p| p.price == price) {
                             bucket.tail = next_key;
                         } else {
                             bucket.tail = None; // Successor is in another bucket, this bucket is now empty of its tail.
@@ -525,13 +525,11 @@ impl<'a> Iterator for OrderBookDirectIterator<'a> {
                 let order = &self.orders[key];
                 self.current_order_key = order.prev;
                 return Some(order as &dyn OrderTrait);
+            } else if let Some(bucket) = self.bucket_iter.next() {
+                self.current_order_key = bucket.tail;
+                continue;
             } else {
-                if let Some(bucket) = self.bucket_iter.next() {
-                    self.current_order_key = bucket.tail;
-                    continue;
-                } else {
-                    return None;
-                }
+                return None;
             }
         }
     }

--- a/orderbook/src/events.rs
+++ b/orderbook/src/events.rs
@@ -1,8 +1,8 @@
 //! This module contains helpers for creating and managing matcher events.
+use crate::OrderCommand;
 use common::cmd::MatcherTradeEvent;
 use common::model::enums::{MatcherEventType, OrderAction};
 use common::model::order::OrderTrait;
-use crate::OrderCommand;
 use common::model::symbol_specification::CoreSymbolSpecification;
 
 pub struct EventHelper;
@@ -57,7 +57,7 @@ impl EventHelper {
     ) -> Box<MatcherTradeEvent> {
         Box::new(MatcherTradeEvent {
             event_type: MatcherEventType::Trade,
-            section: 0, // TODO
+            section: 0,                                            // TODO
             active_order_completed: active_order_cmd.size == size, // Simplified
             matched_order_id,
             matched_order_uid,
@@ -74,4 +74,4 @@ impl EventHelper {
             next_event: None,
         })
     }
-} 
+}

--- a/orderbook/src/lib.rs
+++ b/orderbook/src/lib.rs
@@ -1,16 +1,16 @@
-use common::model::order::{OrderTrait, Order};
+use borsh::{BorshDeserialize, BorshSerialize};
 use common::model::enums::OrderAction;
 use common::model::l2_market_data::L2MarketData;
+use common::model::order::{Order, OrderTrait};
 use common::model::symbol_specification::CoreSymbolSpecification;
-use borsh::{BorshDeserialize, BorshSerialize};
 use std::fmt;
 
-pub use common::cmd::{OrderCommand, MatcherTradeEvent, OrderCommandType};
+pub use common::cmd::{MatcherTradeEvent, OrderCommand, OrderCommandType};
 pub use common::model::enums::SymbolType;
 
-pub mod naive_impl;
-pub mod events;
 pub mod direct_impl;
+pub mod events;
+pub mod naive_impl;
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum OrderBookError {
@@ -48,8 +48,14 @@ pub trait OrderBook<'a> {
     fn get_total_orders_volume(&self, action: OrderAction) -> i64;
     fn get_order_by_id(&self, order_id: i64) -> Option<&dyn OrderTrait>;
     fn find_user_orders(&self, uid: i64) -> Vec<Order>;
-    fn ask_orders_stream(&'a self, sorted: bool) -> Box<dyn Iterator<Item = &'a dyn OrderTrait> + 'a>;
-    fn bid_orders_stream(&'a self, sorted: bool) -> Box<dyn Iterator<Item = &'a dyn OrderTrait> + 'a>;
+    fn ask_orders_stream(
+        &'a self,
+        sorted: bool,
+    ) -> Box<dyn Iterator<Item = &'a dyn OrderTrait> + 'a>;
+    fn bid_orders_stream(
+        &'a self,
+        sorted: bool,
+    ) -> Box<dyn Iterator<Item = &'a dyn OrderTrait> + 'a>;
     fn get_l2_market_data_snapshot(&self, size: usize) -> L2MarketData;
     fn publish_l2_market_data_snapshot(&self, data: &mut L2MarketData);
     fn fill_asks(&self, size: usize, data: &mut L2MarketData);
@@ -61,13 +67,15 @@ pub trait OrderBook<'a> {
     fn validate_internal_state(&self);
 }
 
-pub fn from_bytes<'a>(bytes: &mut &'a[u8]) -> Result<Box<dyn OrderBook<'a> + 'a>, borsh::io::Error> {
+pub fn from_bytes<'a>(
+    bytes: &mut &'a [u8],
+) -> Result<Box<dyn OrderBook<'a> + 'a>, borsh::io::Error> {
     let impl_type = OrderBookImplType::deserialize(bytes)?;
     match impl_type {
         OrderBookImplType::Naive => {
             let book = naive_impl::OrderBookNaiveImpl::from_bytes(bytes)?;
             Ok(Box::new(book))
-        },
+        }
         OrderBookImplType::Direct => {
             let book = direct_impl::OrderBookDirectImpl::from_bytes(bytes)?;
             Ok(Box::new(book))

--- a/orderbook/src/naive_impl.rs
+++ b/orderbook/src/naive_impl.rs
@@ -73,7 +73,7 @@ impl OrdersBucketNaive {
         None
     }
 
-    pub fn match_order<'a>(
+    pub fn match_order(
         &mut self,
         cmd: &OrderCommand,
         mut volume_to_collect: i64,

--- a/orderbook/src/naive_impl.rs
+++ b/orderbook/src/naive_impl.rs
@@ -1,13 +1,13 @@
-use common::model::order::{OrderTrait, Order};
-use common::model::enums::{OrderAction, OrderType};
-use common::model::symbol_specification::CoreSymbolSpecification;
-use crate::{OrderBook, OrderBookImplType, OrderCommand, OrderBookError, MatcherTradeEvent};
 use crate::events::EventHelper;
-use tracing::warn;
-use std::collections::BTreeMap;
-use hashbrown::HashMap;
+use crate::{MatcherTradeEvent, OrderBook, OrderBookError, OrderBookImplType, OrderCommand};
 use borsh::{BorshDeserialize, BorshSerialize};
+use common::model::enums::{OrderAction, OrderType};
+use common::model::order::{Order, OrderTrait};
+use common::model::symbol_specification::CoreSymbolSpecification;
+use hashbrown::HashMap;
 use hashlink::LinkedHashMap;
+use std::collections::BTreeMap;
+use tracing::warn;
 
 #[derive(Clone)]
 pub struct OrdersBucketNaive {
@@ -91,7 +91,8 @@ impl OrdersBucketNaive {
                 break;
             }
 
-            let trade_size = std::cmp::min(volume_to_collect, maker_order.size - maker_order.filled);
+            let trade_size =
+                std::cmp::min(volume_to_collect, maker_order.size - maker_order.filled);
             if trade_size > 0 {
                 total_matching_volume += trade_size;
                 maker_order.filled += trade_size;
@@ -123,9 +124,13 @@ impl OrdersBucketNaive {
             self.entries.remove(order_id);
         }
 
-        (total_matching_volume, events, orders_to_remove, partially_matched_orders)
+        (
+            total_matching_volume,
+            events,
+            orders_to_remove,
+            partially_matched_orders,
+        )
     }
-
 
     pub fn get_num_orders(&self) -> i32 {
         self.entries.len() as i32
@@ -199,7 +204,9 @@ impl OrderBookNaiveImpl {
             &mut self.bid_buckets
         };
 
-        let bucket = buckets.entry(order.price).or_insert_with(|| OrdersBucketNaive::new(order.price));
+        let bucket = buckets
+            .entry(order.price)
+            .or_insert_with(|| OrdersBucketNaive::new(order.price));
         bucket.put(&order);
         self.order_id_map.insert(order.order_id, order);
 
@@ -215,17 +222,26 @@ impl OrderBookNaiveImpl {
         let price = cmd.price;
         let action = cmd.action;
 
-        let (matching_buckets, keys_to_iterate): (
-            &mut BTreeMap<i64, OrdersBucketNaive>,
-            Vec<i64>
-        ) = if action == OrderAction::Bid {
-            let keys: Vec<_> = self.ask_buckets.keys().filter(|&&p| p <= price).cloned().collect();
-            (&mut self.ask_buckets, keys)
-        } else {
-            let keys: Vec<_> = self.bid_buckets.keys().rev().filter(|&&p| p >= price).cloned().collect();
-            (&mut self.bid_buckets, keys)
-        };
-        
+        let (matching_buckets, keys_to_iterate): (&mut BTreeMap<i64, OrdersBucketNaive>, Vec<i64>) =
+            if action == OrderAction::Bid {
+                let keys: Vec<_> = self
+                    .ask_buckets
+                    .keys()
+                    .filter(|&&p| p <= price)
+                    .cloned()
+                    .collect();
+                (&mut self.ask_buckets, keys)
+            } else {
+                let keys: Vec<_> = self
+                    .bid_buckets
+                    .keys()
+                    .rev()
+                    .filter(|&&p| p >= price)
+                    .cloned()
+                    .collect();
+                (&mut self.bid_buckets, keys)
+            };
+
         let mut buckets_to_remove = Vec::new();
 
         for bucket_price in keys_to_iterate {
@@ -234,7 +250,8 @@ impl OrderBookNaiveImpl {
             }
 
             if let Some(bucket) = matching_buckets.get_mut(&bucket_price) {
-                let (matched_volume, events, removed_orders, partially_matched) = bucket.match_order(cmd, remaining_size, &self.symbol_spec);
+                let (matched_volume, events, removed_orders, partially_matched) =
+                    bucket.match_order(cmd, remaining_size, &self.symbol_spec);
 
                 if matched_volume > 0 {
                     filled += matched_volume;
@@ -310,7 +327,11 @@ impl<'a> OrderBook<'a> for OrderBookNaiveImpl {
             }
 
             self.order_id_map.remove(&order.order_id);
-            cmd.attach_matcher_event(EventHelper::send_reduce_event(&order, order.size - order.filled, true));
+            cmd.attach_matcher_event(EventHelper::send_reduce_event(
+                &order,
+                order.size - order.filled,
+                true,
+            ));
             Ok(())
         } else {
             Err(OrderBookError::UnknownOrderId)
@@ -356,10 +377,11 @@ impl<'a> OrderBook<'a> for OrderBookNaiveImpl {
                 self.order_id_map.insert(order.order_id, order); // re-insert
                 return Err(OrderBookError::UnknownOrderId);
             }
-            
-            if self.symbol_spec.symbol_type == common::model::enums::SymbolType::CurrencyExchangePair 
-                && order.action == OrderAction::Bid 
-                && cmd.price > order.reserve_bid_price 
+
+            if self.symbol_spec.symbol_type
+                == common::model::enums::SymbolType::CurrencyExchangePair
+                && order.action == OrderAction::Bid
+                && cmd.price > order.reserve_bid_price
             {
                 // Put the order back before returning
                 self.order_id_map.insert(order.order_id, order);
@@ -367,7 +389,11 @@ impl<'a> OrderBook<'a> for OrderBookNaiveImpl {
             }
 
             // Remove from old bucket
-            let old_buckets = if order.action == OrderAction::Ask { &mut self.ask_buckets } else { &mut self.bid_buckets };
+            let old_buckets = if order.action == OrderAction::Ask {
+                &mut self.ask_buckets
+            } else {
+                &mut self.bid_buckets
+            };
             let mut remove_bucket = false;
             if let Some(bucket) = old_buckets.get_mut(&order.price) {
                 bucket.remove(order.order_id, order.uid);
@@ -382,8 +408,14 @@ impl<'a> OrderBook<'a> for OrderBookNaiveImpl {
             order.price = cmd.price;
 
             // Insert into new bucket
-            let new_buckets = if order.action == OrderAction::Ask { &mut self.ask_buckets } else { &mut self.bid_buckets };
-            let bucket = new_buckets.entry(order.price).or_insert_with(|| OrdersBucketNaive::new(order.price));
+            let new_buckets = if order.action == OrderAction::Ask {
+                &mut self.ask_buckets
+            } else {
+                &mut self.bid_buckets
+            };
+            let bucket = new_buckets
+                .entry(order.price)
+                .or_insert_with(|| OrdersBucketNaive::new(order.price));
             bucket.put(&order);
             self.order_id_map.insert(order.order_id, order);
 
@@ -398,7 +430,10 @@ impl<'a> OrderBook<'a> for OrderBookNaiveImpl {
             &self.ask_buckets
         } else {
             &self.bid_buckets
-        }).values().map(|b| b.get_num_orders()).sum()
+        })
+        .values()
+        .map(|b| b.get_num_orders())
+        .sum()
     }
 
     fn get_total_orders_volume(&self, action: OrderAction) -> i64 {
@@ -407,21 +442,31 @@ impl<'a> OrderBook<'a> for OrderBookNaiveImpl {
         } else {
             &self.bid_buckets
         })
-            .values()
-            .map(|b| b.get_total_volume())
-            .sum()
+        .values()
+        .map(|b| b.get_total_volume())
+        .sum()
     }
 
     fn get_order_by_id(&self, order_id: i64) -> Option<&dyn OrderTrait> {
-        self.order_id_map.get(&order_id).map(|o| o as &dyn OrderTrait)
+        self.order_id_map
+            .get(&order_id)
+            .map(|o| o as &dyn OrderTrait)
     }
 
     fn find_user_orders(&self, uid: i64) -> Vec<Order> {
-        self.order_id_map.values().filter(|o| o.uid == uid).cloned().collect()
+        self.order_id_map
+            .values()
+            .filter(|o| o.uid == uid)
+            .cloned()
+            .collect()
     }
 
-    fn ask_orders_stream(&'a self, sorted: bool) -> Box<dyn Iterator<Item=&'a dyn OrderTrait> + 'a> {
-        let iter = self.ask_buckets
+    fn ask_orders_stream(
+        &'a self,
+        sorted: bool,
+    ) -> Box<dyn Iterator<Item = &'a dyn OrderTrait> + 'a> {
+        let iter = self
+            .ask_buckets
             .values()
             .flat_map(|bucket| bucket.entries.values())
             .map(|o| o as &dyn OrderTrait);
@@ -434,8 +479,12 @@ impl<'a> OrderBook<'a> for OrderBookNaiveImpl {
         }
     }
 
-    fn bid_orders_stream(&'a self, sorted: bool) -> Box<dyn Iterator<Item=&'a dyn OrderTrait> + 'a> {
-        let iter = self.bid_buckets
+    fn bid_orders_stream(
+        &'a self,
+        sorted: bool,
+    ) -> Box<dyn Iterator<Item = &'a dyn OrderTrait> + 'a> {
+        let iter = self
+            .bid_buckets
             .values()
             .rev() // Bids are high to low
             .flat_map(|bucket| bucket.entries.values())
@@ -449,7 +498,10 @@ impl<'a> OrderBook<'a> for OrderBookNaiveImpl {
         }
     }
 
-    fn get_l2_market_data_snapshot(&self, size: usize) -> common::model::l2_market_data::L2MarketData {
+    fn get_l2_market_data_snapshot(
+        &self,
+        size: usize,
+    ) -> common::model::l2_market_data::L2MarketData {
         let asks_size = self.get_total_ask_buckets(size);
         let bids_size = self.get_total_bid_buckets(size);
         let mut data = common::model::l2_market_data::L2MarketData::with_size(asks_size, bids_size);
@@ -458,7 +510,10 @@ impl<'a> OrderBook<'a> for OrderBookNaiveImpl {
         data
     }
 
-    fn publish_l2_market_data_snapshot(&self, data: &mut common::model::l2_market_data::L2MarketData) {
+    fn publish_l2_market_data_snapshot(
+        &self,
+        data: &mut common::model::l2_market_data::L2MarketData,
+    ) {
         self.fill_asks(data.ask_prices.capacity(), data);
         self.fill_bids(data.bid_prices.capacity(), data);
     }
@@ -506,4 +561,4 @@ impl<'a> OrderBook<'a> for OrderBookNaiveImpl {
     fn validate_internal_state(&self) {
         // No-op for naive implementation
     }
-} 
+}

--- a/orderbook/tests/fees.rs
+++ b/orderbook/tests/fees.rs
@@ -1,8 +1,8 @@
 //! Tests for fee calculations.
-use orderbook::{OrderBook, OrderCommand};
-use orderbook::naive_impl::OrderBookNaiveImpl;
 use common::model::enums::{OrderAction, OrderType};
 use common::model::symbol_specification::{CoreSymbolSpecification, TestConstants};
+use orderbook::naive_impl::OrderBookNaiveImpl;
+use orderbook::{OrderBook, OrderCommand};
 
 fn get_fee_testing_spec() -> CoreSymbolSpecification {
     // Use a spec with non-zero fees for testing
@@ -15,20 +15,25 @@ fn should_calculate_fees_on_trade() {
     let mut order_book = OrderBookNaiveImpl::new(spec.clone());
 
     // Setup maker order
-    let mut maker_cmd = OrderCommand::new_order(OrderType::Gtc, 1, 100, 20000, 0, 10, OrderAction::Ask);
+    let mut maker_cmd =
+        OrderCommand::new_order(OrderType::Gtc, 1, 100, 20000, 0, 10, OrderAction::Ask);
     order_book.new_order(&mut maker_cmd).unwrap();
 
     // Execute taker order that matches the maker
-    let mut taker_cmd = OrderCommand::new_order(OrderType::Ioc, 2, 200, 20000, 0, 5, OrderAction::Bid);
+    let mut taker_cmd =
+        OrderCommand::new_order(OrderType::Ioc, 2, 200, 20000, 0, 5, OrderAction::Bid);
     order_book.new_order(&mut taker_cmd).unwrap();
 
     // Verify the trade event and fees
     assert!(taker_cmd.matcher_event.is_some());
     let event = taker_cmd.matcher_event.unwrap();
 
-    assert_eq!(event.event_type, common::model::enums::MatcherEventType::Trade);
+    assert_eq!(
+        event.event_type,
+        common::model::enums::MatcherEventType::Trade
+    );
     assert_eq!(event.size, 5);
-    
+
     // Taker fee = size * taker_fee_per_lot
     let expected_taker_fee = 5 * spec.taker_fee;
     assert_eq!(event.taker_fee, expected_taker_fee);
@@ -80,7 +85,7 @@ fn should_handle_multiple_fee_events() {
     assert_eq!(event.size, 3);
     assert_eq!(event.taker_fee, 3 * spec.taker_fee);
     assert_eq!(event.maker_fee, 3 * spec.maker_fee);
-    
+
     // Second trade
     assert!(event.next_event.is_some());
     let event2 = event.next_event.unwrap();
@@ -118,4 +123,4 @@ fn should_have_zero_fees_for_symbols_without_them() {
     let event = taker_cmd.matcher_event.unwrap();
     assert_eq!(event.taker_fee, 0);
     assert_eq!(event.maker_fee, 0);
-} 
+}

--- a/orderbook/tests/serialization.rs
+++ b/orderbook/tests/serialization.rs
@@ -1,8 +1,8 @@
 //! Tests for serialization and deserialization of the order book.
+use common::model::enums::{OrderAction, OrderType};
+use common::model::symbol_specification::TestConstants;
 use orderbook::naive_impl::OrderBookNaiveImpl;
 use orderbook::{OrderBook, OrderCommand};
-use common::model::enums::{OrderAction, OrderType};
-use common::model::symbol_specification::{TestConstants};
 
 #[test]
 fn test_naive_serialization_deserialization() {
@@ -21,8 +21,20 @@ fn test_naive_serialization_deserialization() {
     let mut reader = bytes.as_slice();
     let deserialized_book = OrderBookNaiveImpl::from_bytes(&mut reader).unwrap();
 
-    assert_eq!(order_book.get_orders_num(OrderAction::Ask), deserialized_book.get_orders_num(OrderAction::Ask));
-    assert_eq!(order_book.get_orders_num(OrderAction::Bid), deserialized_book.get_orders_num(OrderAction::Bid));
-    assert_eq!(order_book.get_total_orders_volume(OrderAction::Ask), deserialized_book.get_total_orders_volume(OrderAction::Ask));
-    assert_eq!(order_book.get_total_orders_volume(OrderAction::Bid), deserialized_book.get_total_orders_volume(OrderAction::Bid));
-} 
+    assert_eq!(
+        order_book.get_orders_num(OrderAction::Ask),
+        deserialized_book.get_orders_num(OrderAction::Ask)
+    );
+    assert_eq!(
+        order_book.get_orders_num(OrderAction::Bid),
+        deserialized_book.get_orders_num(OrderAction::Bid)
+    );
+    assert_eq!(
+        order_book.get_total_orders_volume(OrderAction::Ask),
+        deserialized_book.get_total_orders_volume(OrderAction::Ask)
+    );
+    assert_eq!(
+        order_book.get_total_orders_volume(OrderAction::Bid),
+        deserialized_book.get_total_orders_volume(OrderAction::Bid)
+    );
+}

--- a/orderbook/tests/symbol_specification.rs
+++ b/orderbook/tests/symbol_specification.rs
@@ -7,7 +7,7 @@ use orderbook::{OrderBook, OrderBookError, OrderCommand};
 fn should_get_symbol_specification() {
     let symbol_spec = TestConstants::symbol_spec_eth_xbt();
     let order_book = OrderBookNaiveImpl::new(symbol_spec.clone());
-    
+
     let retrieved_spec = order_book.get_symbol_spec();
     assert_eq!(retrieved_spec.symbol_id, TestConstants::SYMBOL_EXCHANGE);
     assert_eq!(retrieved_spec.symbol_type, SymbolType::CurrencyExchangePair);
@@ -19,11 +19,11 @@ fn should_get_symbol_specification() {
 fn should_validate_internal_state() {
     let symbol_spec = TestConstants::symbol_spec_eth_xbt();
     let mut order_book = OrderBookNaiveImpl::new(symbol_spec);
-    
+
     // Add some orders
     let mut cmd = OrderCommand::new_order(OrderType::Gtc, 1, 100, 50000, 0, 10, OrderAction::Ask);
     order_book.new_order(&mut cmd).unwrap();
-    
+
     // Validation should pass
     order_book.validate_internal_state();
 }
@@ -72,16 +72,14 @@ fn should_work_with_different_symbol_types() {
     // Test with a currency exchange spec
     let currency_spec = TestConstants::symbol_spec_eth_xbt();
     let mut currency_book = OrderBookNaiveImpl::new(currency_spec.clone());
-    let mut cmd1 =
-        OrderCommand::new_order(OrderType::Gtc, 1, 100, 50000, 0, 10, OrderAction::Ask);
+    let mut cmd1 = OrderCommand::new_order(OrderType::Gtc, 1, 100, 50000, 0, 10, OrderAction::Ask);
     currency_book.new_order(&mut cmd1).unwrap();
     assert_eq!(currency_book.get_symbol_spec().symbol_id, 9269);
 
     // Test with a futures contract spec
     let futures_spec = TestConstants::symbol_spec_eur_usd();
     let mut futures_book = OrderBookNaiveImpl::new(futures_spec.clone());
-    let mut cmd2 =
-        OrderCommand::new_order(OrderType::Gtc, 2, 200, 12000, 0, 5, OrderAction::Bid);
+    let mut cmd2 = OrderCommand::new_order(OrderType::Gtc, 2, 200, 12000, 0, 5, OrderAction::Bid);
     futures_book.new_order(&mut cmd2).unwrap();
     assert_eq!(futures_book.get_symbol_spec().symbol_id, 5991);
 }
@@ -90,12 +88,12 @@ fn should_work_with_different_symbol_types() {
 fn should_calculate_state_hash() {
     let symbol_spec = TestConstants::symbol_spec_eth_xbt();
     let hash1 = symbol_spec.state_hash();
-    
+
     // Same spec should produce same hash
     let symbol_spec2 = TestConstants::symbol_spec_eth_xbt();
     let hash2 = symbol_spec2.state_hash();
     assert_eq!(hash1, hash2);
-    
+
     // Different spec should produce different hash
     let symbol_spec3 = TestConstants::symbol_spec_eur_usd();
     let hash3 = symbol_spec3.state_hash();
@@ -126,4 +124,4 @@ fn should_get_l2_market_data_snapshot() {
 
     let l2_data = order_book.get_l2_market_data_snapshot(10);
     assert_eq!(l2_data.ask_prices.len(), 1);
-} 
+}


### PR DESCRIPTION
removed --deny warnings to supress warnings in the audit
affected files:
.github/workflows/ci.yml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved code formatting, import organization, and whitespace consistency throughout the project for better readability and maintainability.
  - Added a configuration to suppress a specific security advisory during dependency audits.
- **Style**
  - Reformatted function and method signatures to span multiple lines for enhanced clarity in some modules.
  - Aligned comments and cleaned up trailing spaces across various files.
- **Tests**
  - Reformatted test code for improved readability; no changes to test logic or coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->