### PR TITLE
feat: Add JournalingProcessor for Persistent Logging 

### DIFF
--- a/processors/src/journaling.rs
+++ b/processors/src/journaling.rs
@@ -1,0 +1,30 @@
+use common::cmd::MatcherTradeEvent;
+use common::cmd::OrderCommand;
+
+/// Responsible for writing all commands and events to a persistent log for durability.
+/// This is the Rust equivalent of `JournalingProcessor.java`.
+pub struct JournalingProcessor;
+
+impl JournalingProcessor {
+    pub fn new() -> Self {
+        Self
+    }
+
+    // Ring buffer Disruptor to JournalingProcessor - Logger(Excali-0)
+    pub fn journal_command(&self, cmd: &OrderCommand) {
+        println!("[Journal] Writing command to disk: ID {}", cmd.order_id);
+    }
+
+    pub fn journal_event(&self, event: &MatcherTradeEvent) {
+        println!(
+            "[Journal] Writing event to disk: Type {:?}",
+            event.event_type
+        );
+    }
+}
+
+impl Default for JournalingProcessor {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/processors/src/matching_engine.rs
+++ b/processors/src/matching_engine.rs
@@ -1,9 +1,16 @@
 use common::cmd::OrderCommand;
 use hashbrown::HashMap;
-use orderbook::OrderBook;
+use orderbook::{OrderBook, OrderBookError};
 use orderbook::OrderBookImplType;
 use orderbook::direct_impl::OrderBookDirectImpl;
 use orderbook::naive_impl::OrderBookNaiveImpl;
+
+/// Custom error type for routing failures.
+#[derive(Debug)]
+pub enum RoutingError {
+    OrderBookNotFound,
+    ProcessingFailed(OrderBookError),
+}
 
 /// Owns all order books and routes commands to the correct one.
 /// This is the Rust equivalent of `MatchingEngineRouter.java`.
@@ -30,27 +37,27 @@ impl MatchingEngineRouter {
 
     /// Routes a command to the appropriate order book for processing.
     /// This is the core matching stage(Excali-6b) of the pipeline.
-    pub fn route_command(&mut self, cmd: &mut OrderCommand) {
-        if let Some(order_book) = self.order_books.get_mut(&cmd.symbol) {
-            println!(
-                "[Router] Routing command for symbol {} to its order book.",
-                cmd.symbol
-            );
-            // Events are created inside these methods(excali-7)
-            let result = match cmd.command {
-                common::cmd::OrderCommandType::PlaceOrder => order_book.new_order(cmd),
-                common::cmd::OrderCommandType::CancelOrder => order_book.cancel_order(cmd),
-                common::cmd::OrderCommandType::MoveOrder => order_book.move_order(cmd),
-                common::cmd::OrderCommandType::ReduceOrder => order_book.reduce_order(cmd),
-            };
-            println!("[Router] Order book processed command: {:?}", cmd);
+    pub fn route_command(&mut self, cmd: &mut OrderCommand) -> Result<(), RoutingError> {
+        let order_book = self
+            .order_books
+            .get_mut(&cmd.symbol)
+            .ok_or(RoutingError::OrderBookNotFound)?;
 
-            if let Err(e) = result {
-                tracing::warn!("[Router] Order book processing failed: {:?}", e);
-            }
-        } else {
-            tracing::warn!("[Router] No order book found for symbol {}", cmd.symbol);
-        }
+        println!(
+            "[Router] Routing command for symbol {} to its order book.",
+            cmd.symbol
+        );
+
+        // Events are created inside these methods(excali-7)
+        let result = match cmd.command {
+            common::cmd::OrderCommandType::PlaceOrder => order_book.new_order(cmd),
+            common::cmd::OrderCommandType::CancelOrder => order_book.cancel_order(cmd),
+            common::cmd::OrderCommandType::MoveOrder => order_book.move_order(cmd),
+            common::cmd::OrderCommandType::ReduceOrder => order_book.reduce_order(cmd),
+        };
+        println!("[Router] Order book processed command: {:?}", cmd);
+
+        result.map_err(RoutingError::ProcessingFailed)
     }
 }
 


### PR DESCRIPTION
- The `JournalingProcessor` is responsible for writing all order commands and trade events to a persistent log for durability. 
- The journaling processor is designed to be used before and after the matching engine, ensuring that all processed commands and events are reliably logged. 
- This is the Rust equivalent of the `JournalingProcessor.java` and provides methods to log both commands and matcher trade events. 
- The implementation currently uses simple `println!` statements as placeholders for actual disk writes, which can be extended in the future for real persistence mechanisms.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added journaling to persist commands and trade events for durability and auditability.
  * Introduced a matching engine router that manages multiple symbols and routes orders by symbol.
  * Enabled selection of different order book implementations per symbol.

* **Improvements**
  * Clearer routing errors when a symbol is missing or processing fails.
  * Added progress logging for routing and order processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->