### PR TITLE
feat: Add ExchangeApi Interface for External Command Submission

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -1,0 +1,23 @@
+use common::cmd::OrderCommand;
+use tokio::sync::mpsc;
+
+#[derive(Clone)]
+// ExchangeApi is the interface through which external clients can interact with the exchange core.
+// (later it will be a client gateway sending events on to the ringbuffer disruptor and from there to the risk engine, matching engine, etc.)
+pub struct ExchangeApi {
+    command_tx: mpsc::Sender<OrderCommand>,
+}
+
+impl ExchangeApi {
+    // Creates a new instance of ExchangeApi with the provided command sender.
+    pub fn new(command_tx: mpsc::Sender<OrderCommand>) -> Self {
+        Self { command_tx }
+    }
+    // Submits a command to the exchange core.
+    pub async fn submit_command(&self, cmd: OrderCommand) -> Result<(), &'static str> {
+        self.command_tx
+            .send(cmd)
+            .await
+            .map_err(|_| "Failed to send command to core")
+    }
+}


### PR DESCRIPTION
- This PR introduces the `ExchangeApi` struct, providing a unified interface for external clients to interact with the exchange core. 
- The API wraps a Tokio MPSC sender for `OrderCommand` messages, allowing asynchronous command submission to the core after all processors (such as risk engine, matching engine, etc.) have been set up. 
- This abstraction will later serve as a client gateway, forwarding events to the ringbuffer disruptor and subsequently to the core processors. 
- The API includes methods for instantiation and command submission, with error handling for failed transmissions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a client-facing API to interact with the exchange, allowing external applications to asynchronously submit order commands with immediate success/failure feedback.
  * The API handle is lightweight and can be safely duplicated across tasks for concurrent use, improving integration flexibility and throughput.
  * Enables easier service-to-service integration and simplifies building automated trading workflows.
  * No changes to existing UI or manual user flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->