### PR TITLE
feat: add main.rs to Use and test All Components in Exchange Initialization and Final Event Assertion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -373,6 +373,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "processors"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "common",
+ "hashbrown",
+ "orderbook",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -642,7 +655,9 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "common",
+ "hashbrown",
  "orderbook",
+ "processors",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 # Workspace crates containing our data models and order book logic
 common = { path = "./common" }
 orderbook = { path = "./orderbook" }
+processors = { path = "./processors" }
 
 # High-level async runtime and message passing channels
 tokio = { version = "1", features = ["full"] }
@@ -17,12 +18,13 @@ tracing-subscriber = "0.3"
 
 # Trait for async functions in traits
 async-trait = "0.1"
+hashbrown.workspace = true
 
 [workspace]
 resolver = "2"
 members = [
     "common",
-    "orderbook",
+    "orderbook", "processors",
 ]
 
 [workspace.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,8 @@ hashbrown.workspace = true
 resolver = "2"
 members = [
     "common",
-    "orderbook", "processors",
+    "orderbook",
+    "processors",
 ]
 
 [workspace.dependencies]

--- a/processors/src/matching_engine.rs
+++ b/processors/src/matching_engine.rs
@@ -1,9 +1,9 @@
 use common::cmd::OrderCommand;
 use hashbrown::HashMap;
-use orderbook::{OrderBook, OrderBookError};
 use orderbook::OrderBookImplType;
 use orderbook::direct_impl::OrderBookDirectImpl;
 use orderbook::naive_impl::OrderBookNaiveImpl;
+use orderbook::{OrderBook, OrderBookError};
 
 /// Custom error type for routing failures.
 #[derive(Debug)]

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -75,22 +75,19 @@ impl CoreEngine {
             while let Some(event_box) = current_event {
                 let mut event = *event_box;
                 current_event = event.next_event.take();
-                println!("[Sequential Core] Processing event: {:?}", event);
+                println!("[Sequential Core] Processing event: {event:?}");
 
                 // 3a. Journal the resulting event. -- excali 0
                 self.journaling_processor.journal_event(&event);
-                println!("[Sequential Core] Event journaled: {:?}", event);
+                println!("[Sequential Core] Event journaled: {event:?}");
 
                 // 3b. Risk Engine handles financial settlement. -- excali 8a
                 self.risk_engine.handle_event(&event);
-                println!("[Sequential Core] Risk Engine processed event: {:?}", event);
+                println!("[Sequential Core] Risk Engine processed event: {event:?}");
 
                 // 3c. External handler sends results to clients. -- excali 8b
                 self.events_handler.handle_event(event.clone()).await;
-                println!(
-                    "[Sequential Core] Event sent to external handler: {:?}",
-                    event
-                );
+                println!("[Sequential Core] Event sent to external handler: {event:?}");
             }
         }
         println!("[Sequential Core] Engine stopped.");

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,115 @@
-fn main() {
-    println!("Hello, vex-core!");
+mod api;
+mod engine;
+mod events;
+
+use api::ExchangeApi;
+use common::cmd::OrderCommand;
+use common::model::{
+    enums::{OrderAction, OrderType},
+    user_profile::{UserProfile, UserStatus},
+};
+use engine::CoreEngine;
+use events::SimpleEventsHandler;
+use orderbook::OrderBookImplType;
+use processors::{
+    journaling::JournalingProcessor, matching_engine::MatchingEngineRouter, risk_engine::RiskEngine,
+};
+use std::sync::Arc;
+use tokio::sync::mpsc;
+
+// Sets up the entire Exchange Core application with all processors.
+pub fn init_exchange() -> (ExchangeApi, CoreEngine, Arc<SimpleEventsHandler>) {
+    let (command_tx, command_rx) = mpsc::channel(1024);
+
+    // Initialize the matching engine router with a default order book.
+    let mut matching_engine_router = MatchingEngineRouter::new();
+    matching_engine_router.add_symbol(0, OrderBookImplType::Naive);
+
+    // Create a risk engine with a user profile(say 100 here)
+    let mut risk_engine = RiskEngine::new();
+    risk_engine
+        .user_profiles
+        .insert(100, UserProfile::new(100, UserStatus::Active));
+
+    // Initialize the journaling processor to log commands and events.
+    let journaling_processor = JournalingProcessor::new();
+
+    // Create a events handler to collect and process events.
+    let events_handler = Arc::new(SimpleEventsHandler::new()); // shared with core
+
+    // Create the Exchange Core with all components wired together.
+    let core_engine = CoreEngine::new(
+        command_rx,
+        risk_engine,
+        matching_engine_router,
+        journaling_processor,
+        events_handler.clone(),
+    );
+
+    // Create the Exchange API that will allow external clients to submit commands.
+    let exchange_api = ExchangeApi::new(command_tx);
+
+    (exchange_api, core_engine, events_handler)
+}
+
+// Simulates a gateway receiving a message from a client over the network (will be from Aeron later).
+async fn run_dummy_gateway_listener(api: ExchangeApi) {
+    println!("[Dummy Client Gateway] Simulating message received from client...");
+
+    let new_order_cmd =
+        OrderCommand::new_order(OrderType::Gtc, 1, 100, 9629, 1500, 10, OrderAction::Bid);
+
+    println!("[Dummy Gateway] Submitting command to the Exchange API...");
+    api.submit_command(new_order_cmd).await.unwrap();
+    println!("[Dummy Gateway] Command submitted successfully.");
+}
+
+#[tokio::main]
+async fn main() {
+    // Initialize logging to see output from `tracing`.
+    tracing_subscriber::fmt::init();
+
+    println!("--- Running Full Sequential Core Test ---");
+
+    // 1. Set up the entire exchange core with its pipeline.
+    let (api, mut core, handler) = init_exchange();
+
+    // 2. Spawn the core engine to run in the background.
+    let core_handle = tokio::spawn(async move {
+        core.run().await;
+    });
+
+    // 3. Run the dummy gateway to simulate a client sending an order.
+    run_dummy_gateway_listener(api).await;
+
+    // Give the engine a moment to process the command sequentially.
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    // 4. ASSERT: Check that the correct final event was produced and handled.
+    println!("\n--- Asserting final event received by handler ---");
+    // When a GTC order is placed but not matched, it results in a "Reduce" event with matched_order_completed as false
+    // representing the funds being put on hold.
+    let received_events = handler.events.lock().unwrap();
+    assert_eq!(
+        received_events.len(),
+        1,
+        "Should have received exactly one event"
+    );
+
+    let event = &received_events[0];
+    assert_eq!(
+        event.event_type,
+        common::model::enums::MatcherEventType::Reduce
+    );
+    assert!(!event.matched_order_completed);
+    assert_eq!(event.matched_order_id, 1);
+    assert_eq!(event.matched_order_uid, 100);
+    assert_eq!(event.price, 9629);
+    assert_eq!(event.size, 10);
+    println!(
+        "\n--- Test Passed: Full pipeline executed and correct PlaceOrder event was received. ---"
+    );
+
+    // Cleanly shut down the core task and release resources.
+    drop(core_handle);
 }


### PR DESCRIPTION
- The `main.rs` is added to ensure that all core components of the exchange are properly initialized and utilized in the test pipeline. 
- The `init_exchange` function now wires together all processors and handlers, and the main test flow finally asserts that the correct event is received after a simulated client order. 
- This ensures the full pipeline is exercised, from command submission to event handling, providing a integration test for the exchange core.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Modular exchange entrypoint that wires core pipeline (risk, matching, journaling, events) with an async API and a sample gateway that runs a synthetic order and validates event flow.
  * Emits and validates order events through the async handler.

* **Style**
  * Standardized debug log formatting and minor import reordering for clearer logs.

* **Chores**
  * Added a new processors crate to the workspace and enabled workspace usage for a dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->