### PR TITLE
fix: paste crate warning in ci

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,2 @@
+[advisories]
+ignore = ["RUSTSEC-2024-0436"]  # paste crate v1.0.15 - unmaintained

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,11 @@ on:
     push: 
         branches:
             - main
-            - dev
+            - develop
     pull_request: 
         branches:
             - main
-            - dev
+            - develop
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated audit configuration to ignore a specific advisory related to an unmaintained dependency.
  * Adjusted workflow triggers to monitor the "develop" branch instead of "dev".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->