### PR TITLE
fix: resolve the port allocation errors

### DIFF
--- a/networking/src/server/gateway_manager.rs
+++ b/networking/src/server/gateway_manager.rs
@@ -490,6 +490,16 @@ impl GatewayManager {
 
     /// Removes a gateway session and frees all associated resources
     pub fn remove_gateway_session(&self, gateway_id: u8) -> Result<(), ServerError> {
+        // Get ports before removing the session
+        let ports_to_free = {
+            let guard = self.gateway_sessions.read().unwrap();
+            if let Some(slot) = guard.slots.get(gateway_id as usize).and_then(|s| s.as_ref()) {
+                vec![slot.port_data, slot.port_control]
+            } else {
+                vec![]
+            }
+        };
+
         let mut session = match self.gateway_sessions.write().unwrap().remove(gateway_id) {
             Some(duologue) => duologue,
             None => {
@@ -509,6 +519,19 @@ impl GatewayManager {
                 action = "session_close_failed",
                 gateway_id,
                 error = ?e
+            );
+        }
+
+        // Mark ports as recently freed to avoid OS-level port binding race conditions
+        // The OS may still have the UDP port bound even after Aeron closes the subscription
+        if !ports_to_free.is_empty() {
+            self.port_allocator.mark_freed(&ports_to_free);
+            debug!(
+                target: "gateway_manager",
+                action = "ports_marked_freed",
+                gateway_id,
+                data_port = ports_to_free[0],
+                control_port = ports_to_free[1]
             );
         }
 

--- a/networking/src/utils.rs
+++ b/networking/src/utils.rs
@@ -199,12 +199,20 @@ pub fn send_message_with_retries(
 
 /// Port allocator that randomly selects ports from a given range.
 /// Does not track allocated ports - the Session struct is the source of truth.
-#[derive(Debug, Clone)]
+/// Tracks recently freed ports to avoid OS-level port binding race conditions.
+#[derive(Debug)]
 pub struct PortAllocator {
     port_range: std::ops::RangeInclusive<u16>,
     low: u16,
     high: u16,
+    /// Tracks ports that were recently freed with their timestamp
+    /// Ports are kept in this set for PORT_COOLDOWN_SECONDS to allow OS to release them
+    recently_freed_ports: std::sync::RwLock<std::collections::HashMap<u16, std::time::Instant>>,
 }
+
+/// Time to wait before reusing a freed port (in seconds)
+/// This allows the OS to fully release the UDP port binding
+const PORT_COOLDOWN_SECONDS: u64 = 10;
 
 impl PortAllocator {
     /// Create a new port allocator.
@@ -243,6 +251,7 @@ impl PortAllocator {
             port_range,
             low: port_base,
             high: port_hi,
+            recently_freed_ports: std::sync::RwLock::new(std::collections::HashMap::new()),
         })
     }
 
@@ -251,7 +260,7 @@ impl PortAllocator {
         self.port_range.clone().count()
     }
 
-    /// Allocate `count` ports randomly, avoiding the ports already in use.
+    /// Allocate `count` ports randomly, avoiding the ports already in use and recently freed ports.
     ///
     /// # Arguments
     /// * `count` - The number of ports that will be allocated
@@ -268,13 +277,26 @@ impl PortAllocator {
             return Ok(Vec::new());
         }
 
+        // Clean up expired entries from recently_freed_ports
+        self.cleanup_expired_ports();
+
+        // Get list of ports that are still in cooldown
+        let recently_freed: Vec<u16> = {
+            let freed = self.recently_freed_ports.read().unwrap();
+            freed.keys().copied().collect()
+        };
+
         let total = self.total_ports();
         let used = ports_in_use.len();
+        let in_cooldown = recently_freed.len();
 
-        if count > total.saturating_sub(used) {
+        // Account for ports in cooldown when checking availability
+        if count > total.saturating_sub(used).saturating_sub(in_cooldown) {
             return Err(ServerError::ResourceAllocationError(format!(
-                "Requested {count} ports, but only {} available",
-                total - used
+                "Requested {count} ports, but only {} available ({} in use, {} in cooldown)",
+                total.saturating_sub(used).saturating_sub(in_cooldown),
+                used,
+                in_cooldown
             )));
         }
 
@@ -286,17 +308,20 @@ impl PortAllocator {
         while result.len() < count {
             if attempts >= max_attempts {
                 return Err(ServerError::ResourceAllocationError(format!(
-                    "Failed to allocate {} ports after {} attempts ({} already allocated)",
+                    "Failed to allocate {} ports after {} attempts ({} already allocated, {} in cooldown)",
                     count,
                     max_attempts,
-                    result.len()
+                    result.len(),
+                    in_cooldown
                 )));
             }
 
             let port = rng.gen_range(self.low..=self.high);
 
-            // Check if port is not in use and not already in result
-            if !ports_in_use.contains(&port) && !result.contains(&port) {
+            // Check if port is not in use, not in cooldown, and not already in result
+            if !ports_in_use.contains(&port) 
+                && !recently_freed.contains(&port) 
+                && !result.contains(&port) {
                 result.push(port);
             }
 
@@ -304,6 +329,26 @@ impl PortAllocator {
         }
 
         Ok(result)
+    }
+
+    /// Mark ports as recently freed. They will be unavailable for allocation for PORT_COOLDOWN_SECONDS.
+    ///
+    /// # Arguments
+    /// * `ports` - Slice of ports that were just freed
+    pub fn mark_freed(&self, ports: &[u16]) {
+        let now = std::time::Instant::now();
+        let mut freed = self.recently_freed_ports.write().unwrap();
+        for &port in ports {
+            freed.insert(port, now);
+        }
+    }
+
+    /// Remove expired entries from recently_freed_ports
+    fn cleanup_expired_ports(&self) {
+        let now = std::time::Instant::now();
+        let cooldown = std::time::Duration::from_secs(PORT_COOLDOWN_SECONDS);
+        let mut freed = self.recently_freed_ports.write().unwrap();
+        freed.retain(|_, &mut timestamp| now.duration_since(timestamp) < cooldown);
     }
 }
 


### PR DESCRIPTION
## Description
When gateways disconnect and reconnect (retries the aeron subscription) quickly the core can fail to create new aeron subscriptions with the error:
```
ERROR gateway_handler: action="handshake_processing_failed" 
error=Resource allocation error: Failed to create subscription: Aeron error -1: GenericError
[lastErrMsg=... Address already in use ... aeron:udp?endpoint=0.0.0.0:50002|session-id=8904]
```

When a gateway disconnects, the core closes the Aeron subscription asynchronously. The system keeps the UDP port in TIME_WAIT for a few seconds. If a new gateway connects and the core tries to bind the same port before the os will release it, the "Address already in use" error occurs.

## Solution

Added a port cooldown mechanism to the PortAllocator

- Track recently freed ports: When a gateway session is removed, mark its ports as "recently freed" with a timestamp.
- Cooldown period: Keep ports unavailable for 10 seconds (PORT_COOLDOWN_SECONDS) to allow the OS to release them.
- Avoid reuse during cooldown: The allocator skips ports in cooldown when allocating new ports.
- Automatic cleanup: Expired entries are removed from the cooldown set.

