### PR TITLE
fix: reject orders whose collateral requirement rounds to zero

### DIFF
--- a/common/src/market_specification.rs
+++ b/common/src/market_specification.rs
@@ -41,7 +41,7 @@ impl CoreMarketSpecification {
         if denominator == 0 {
             return 0;
         }
-        (numerator / denominator) as u64
+        u64::try_from(numerator / denominator).unwrap_or(u64::MAX)
     }
 }
 

--- a/processors/src/risk_engine.rs
+++ b/processors/src/risk_engine.rs
@@ -306,14 +306,38 @@ impl RiskEngine {
         cmd: &mut OrderCommand,
         price_cache: Arc<PriceCache>,
     ) -> Result<()> {
+        if cmd.size == 0 {
+            return Err(RiskEngineError::InvalidArguments {
+                price: cmd.price,
+                size: cmd.size,
+            });
+        }
+
         let (asset_to_lock, amount_to_lock) = match cmd.side {
             // For a Bid (buy), we lock the quote currency. Amount = price * size.
             Side::Bid => {
                 let amount = self.bid_amount(cmd, price_cache)?;
+                if amount == 0 {
+                    return Err(RiskEngineError::InvalidArguments {
+                        price: cmd.price,
+                        size: cmd.size,
+                    });
+                }
                 (quote_asset(cmd.market_id), amount)
             }
             // For an Ask (sell), we lock the base currency. Amount = size.
-            Side::Ask => (base_asset(cmd.market_id), cmd.size),
+            Side::Ask => {
+                // A market sell carries the price-0 sentinel and is priced by the book at match
+                // time, so there is no order-time notional to check. A *limit* ask whose quote
+                // proceeds floor to zero would hand over base for nothing, so reject it.
+                if cmd.price != 0 && self.ask_proceeds(cmd)? == 0 {
+                    return Err(RiskEngineError::InvalidArguments {
+                        price: cmd.price,
+                        size: cmd.size,
+                    });
+                }
+                (base_asset(cmd.market_id), cmd.size)
+            }
         };
 
         // Acquire a lock on the store and perform the operation
@@ -361,6 +385,19 @@ impl RiskEngine {
             // Limit order
             Ok(spec.calculate_quote_cost(cmd.price, cmd.size))
         }
+    }
+
+    /// Quote proceeds a *limit* ask would earn if it filled entirely at its own price.
+    #[inline]
+    fn ask_proceeds(&self, cmd: &OrderCommand) -> Result<u64> {
+        let spec =
+            self.symbol_specs
+                .get(&cmd.market_id)
+                .ok_or(RiskEngineError::MarketSpecNotFound {
+                    market_id: cmd.market_id,
+                })?;
+
+        Ok(spec.calculate_quote_cost(cmd.price, cmd.size))
     }
 
     /// Releases previously reserved funds from a canceled or filled order.
@@ -572,6 +609,160 @@ mod tests {
         let balance = engine.get_balance(user_id, quote_asset);
         assert_eq!(balance.available(), required_quote);
         assert_eq!(balance.locked(), 0);
+    }
+
+    #[test]
+    fn test_rejects_bid_whose_quote_cost_rounds_to_zero() {
+        let user_id = 1;
+        let market_id = (2_u32 << 16) | 1_u32;
+        let spec = CoreMarketSpecification::builder()
+            .market_id(market_id)
+            .market_type(MarketType::Spot)
+            .base_native_scale(100)
+            .quote_native_scale(1)
+            .build()
+            .unwrap();
+        let mut specs = HashMap::new();
+        specs.insert(market_id, spec);
+        let price_cache = Arc::new(PriceCache::new(specs.keys()));
+        let engine = RiskEngine::new(specs, 0, 1);
+        let mut cmd =
+            OrderCommand::place_order(TimeInForce::Gtc, user_id, 1, 1, Side::Bid, market_id, 1);
+
+        engine.pre_process_command(&mut cmd, price_cache);
+
+        assert_eq!(cmd.status, Status::Rejected);
+    }
+
+    #[test]
+    fn test_rejects_ask_whose_quote_cost_rounds_to_zero() {
+        let user_id = 1;
+        let market_id = (2_u32 << 16) | 1_u32;
+        let spec = CoreMarketSpecification::builder()
+            .market_id(market_id)
+            .market_type(MarketType::Spot)
+            .base_native_scale(100)
+            .quote_native_scale(1)
+            .build()
+            .unwrap();
+        let mut specs = HashMap::new();
+        specs.insert(market_id, spec);
+        let price_cache = Arc::new(PriceCache::new(specs.keys()));
+        let engine = RiskEngine::new(specs, 0, 1);
+        engine.set_balance(user_id, base_asset(market_id), UserBalance::new(1, 0));
+        let mut cmd =
+            OrderCommand::place_order(TimeInForce::Gtc, user_id, 1, 1, Side::Ask, market_id, 1);
+
+        let error = engine
+            .reserve_funds_for_order(&mut cmd, price_cache)
+            .unwrap_err();
+
+        assert!(matches!(error, RiskEngineError::InvalidArguments { .. }));
+    }
+
+    /// A market sell carries the price-0 sentinel (`orderbook/src/lib.rs:425`). Reserving
+    /// collateral for it must succeed: the ask locks `size` of the base asset, which the
+    /// `cmd.size == 0` guard already proves is non-zero.
+    #[test]
+    fn test_market_sell_reserves_collateral() {
+        let user_id = 1;
+        let market_id = (2_u32 << 16) | 1_u32;
+        let size = 10;
+        let mut specs = HashMap::new();
+        specs.insert(market_id, get_spec(market_id));
+        let price_cache = Arc::new(PriceCache::new(specs.keys()));
+        let engine = RiskEngine::new(specs, 0, 1);
+        engine.set_balance(user_id, base_asset(market_id), UserBalance::new(size, 0));
+        // price == 0 is the market-SELL sentinel.
+        let mut cmd =
+            OrderCommand::place_order(TimeInForce::Ioc, user_id, 0, size, Side::Ask, market_id, 1);
+
+        engine
+            .reserve_funds_for_order(&mut cmd, price_cache)
+            .expect("a market sell must be able to reserve collateral");
+
+        let balance = engine.get_balance(user_id, base_asset(market_id));
+        assert_eq!(balance.locked, size, "market sell must lock `size` of base");
+    }
+
+    #[test]
+    fn test_normal_ask_locks_expected_base_amount() {
+        let user_id = 1;
+        let market_id = (2_u32 << 16) | 1_u32;
+        let price = 100;
+        let size = 10;
+        let mut specs = HashMap::new();
+        specs.insert(market_id, get_spec(market_id));
+        let price_cache = Arc::new(PriceCache::new(specs.keys()));
+        let engine = RiskEngine::new(specs, 0, 1);
+        let base_asset = base_asset(market_id);
+        engine.set_balance(user_id, base_asset, UserBalance::new(size, 0));
+        let mut cmd = OrderCommand::place_order(
+            TimeInForce::Gtc,
+            user_id,
+            price,
+            size,
+            Side::Ask,
+            market_id,
+            1,
+        );
+
+        engine
+            .reserve_funds_for_order(&mut cmd, price_cache)
+            .unwrap();
+
+        assert_eq!(
+            engine.get_balance(user_id, base_asset),
+            UserBalance::new(0, size)
+        );
+    }
+
+    #[test]
+    fn test_rejects_zero_size_order() {
+        let user_id = 1;
+        let market_id = (2_u32 << 16) | 1_u32;
+        let mut specs = HashMap::new();
+        specs.insert(market_id, get_spec(market_id));
+        let price_cache = Arc::new(PriceCache::new(specs.keys()));
+        let engine = RiskEngine::new(specs, 0, 1);
+        let mut cmd =
+            OrderCommand::place_order(TimeInForce::Gtc, user_id, 100, 0, Side::Ask, market_id, 1);
+
+        engine.pre_process_command(&mut cmd, price_cache);
+
+        assert_eq!(cmd.status, Status::Rejected);
+    }
+
+    #[test]
+    fn test_normal_bid_locks_expected_quote_amount() {
+        let user_id = 1;
+        let market_id = (2_u32 << 16) | 1_u32;
+        let price = 100;
+        let size = 10;
+        let required_quote = price * size;
+        let mut specs = HashMap::new();
+        specs.insert(market_id, get_spec(market_id));
+        let price_cache = Arc::new(PriceCache::new(specs.keys()));
+        let engine = RiskEngine::new(specs, 0, 1);
+        let quote_asset = quote_asset(market_id);
+        engine.set_balance(user_id, quote_asset, UserBalance::new(required_quote, 0));
+        let mut cmd = OrderCommand::place_order(
+            TimeInForce::Gtc,
+            user_id,
+            price,
+            size,
+            Side::Bid,
+            market_id,
+            1,
+        );
+
+        engine.pre_process_command(&mut cmd, price_cache);
+
+        assert_ne!(cmd.status, Status::Rejected);
+        assert_eq!(
+            engine.get_balance(user_id, quote_asset),
+            UserBalance::new(0, required_quote)
+        );
     }
 
     #[test]
@@ -829,10 +1020,16 @@ mod tests {
         }
 
         // --- Test 4: Market Sell ---
-        // Market sell doesn't depend on price cache, just locks `size` of base asset (BTC).
         engine.set_balance(user_id, btc_asset_id, UserBalance::new(size, 0));
-        let mut market_sell_cmd =
-            OrderCommand::place_order(TimeInForce::Gtc, user_id, 0, size, Side::Ask, market_id, 1);
+        let mut market_sell_cmd = OrderCommand::place_order(
+            TimeInForce::Gtc,
+            user_id,
+            u64::MAX,
+            size,
+            Side::Ask,
+            market_id,
+            1,
+        );
 
         engine
             .reserve_funds_for_order(&mut market_sell_cmd, price_cache.clone())


### PR DESCRIPTION
## The problem

`calculate_quote_cost` is an integer **floor** division with a narrowing cast, so a small enough
notional produces a collateral requirement of exactly zero:

```rust
(numerator / denominator) as u64          // common/src/market_specification.rs:44
```

`lock_funds` succeeds when `amount == 0` even on an account with no balance, so Risk R1 accepted the
order, and settlement then subtracted 0 from locked while crediting the full `size` in base.

With the ETH/USDT scaling shipped in `vex-config` the divisor is `1e13`, so any order where
`price * size < 1e13` was free. Measured against the real engine: an account holding **zero** quote
placed a bid and received 1,000,000,000 base units.

The same cast was also the second path in: a numerator above `u64::MAX` wrapped to a small value, so
an arbitrarily large order could also be made cheap.

## The fix

Three changes, all in the reservation path:

- `calculate_quote_cost` now saturates instead of wrapping (`u64::try_from(..).unwrap_or(u64::MAX)`),
  so an oversized notional becomes unaffordable rather than cheap.
- A BID whose computed quote cost is `0` is rejected via the existing
  `RiskEngineError::InvalidArguments`, which `pre_process_command` already maps to
  `Status::Rejected`.
- `size == 0` is rejected for both sides, since a zero-size order is never legitimate and previously
  rested for free.

No new configuration, no minimum-notional knob, no new error variant — the existing error and
rejection path carry it.

## Cross-reference

`vex-gateway` is the upstream that this engine's docs assume validates notional, and it does not —
its only order validation is `market_id <= i32::MAX`. Tracked there as trade-vex/vex-gateway#48.
This engine-side guard is the backstop that holds regardless of what upstream sends.

This also closes the reachable path for #138 (zero-size orders), since a zero-size order can no
longer pass R1 to reach the book.

## Verification

`cargo check` and `cargo clippy --workspace --all-targets` clean; `cargo test -p processors -p common`
passes with three new tests covering a zero-notional bid, a zero-size order, and a normal bid still
locking the expected amount.

Closes #111


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Safely handle quote cost calculations that exceed the supported value range.
  * Treat zero-priced asks as market sells when reserving collateral.
  * Reject limit asks when calculated proceeds round to zero.
  * Continue rejecting invalid or zero-size orders before funds are locked.
* **Tests**
  * Added coverage for market-sell collateral reservations and standard limit-ask reservations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->