### PR TITLE
fix: validate length and SBE header before decoding an order command

### DIFF
--- a/common/src/cmd.rs
+++ b/common/src/cmd.rs
@@ -2,10 +2,10 @@ use crate::{L2MarketData, OrderCommandType, Side, TimeInForce, UserBalance};
 use borsh::{BorshDeserialize, BorshSerialize};
 use sbe_order::message_header_codec::{self, MessageHeaderDecoder};
 use sbe_order::order_command_message_codec::{
-    OrderCommandMessageDecoder, OrderCommandMessageEncoder,
+    OrderCommandMessageDecoder, OrderCommandMessageEncoder, SBE_BLOCK_LENGTH, SBE_TEMPLATE_ID,
 };
 use sbe_order::status::Status as SbeStatus;
-use sbe_order::{ReadBuf, SbeResult, WriteBuf};
+use sbe_order::{ReadBuf, SBE_SCHEMA_ID, SbeResult, WriteBuf};
 use serde::de::Error;
 use serde::de::value::Error as SerdeError;
 use serde::{Deserialize, Serialize};
@@ -391,9 +391,27 @@ pub fn encode_order_command(order_command: &OrderCommand, buf: &mut [u8]) -> Sbe
 }
 
 pub fn decode_order_command(buf: &[u8]) -> Result<OrderCommand, SerdeError> {
+    if buf.len() < ORDERCOMMANDSIZE {
+        return Err(SerdeError::custom(format!(
+            "OrderCommand buffer is too short: expected at least {ORDERCOMMANDSIZE} bytes, got {}",
+            buf.len()
+        )));
+    }
+
     let buf = ReadBuf::new(buf);
     let mut decoder = OrderCommandMessageDecoder::default();
     let header = MessageHeaderDecoder::default().wrap(buf, 0);
+    if header.block_length() != SBE_BLOCK_LENGTH
+        || header.template_id() != SBE_TEMPLATE_ID
+        || header.schema_id() != SBE_SCHEMA_ID
+    {
+        return Err(SerdeError::custom(format!(
+            "Invalid OrderCommand SBE header: expected block length {SBE_BLOCK_LENGTH}, template id {SBE_TEMPLATE_ID}, schema id {SBE_SCHEMA_ID}; got block length {}, template id {}, schema id {}",
+            header.block_length(),
+            header.template_id(),
+            header.schema_id()
+        )));
+    }
     decoder = decoder.header(header, 0);
     Ok(OrderCommand {
         command: decoder.command().try_into()?,
@@ -429,5 +447,62 @@ mod tests {
         }
 
         drop(chain);
+    }
+
+    fn encoded_command() -> [u8; ORDERCOMMANDSIZE] {
+        let command = OrderCommand {
+            command: OrderCommandType::CancelOrder,
+            client_order_id: 11,
+            order_id: 22,
+            user_id: 33,
+            market_id: 44,
+            price: 55,
+            size: 66,
+            side: Side::Bid,
+            time_in_force: TimeInForce::Fok,
+            timestamp: 77,
+            status: Status::Cancelled,
+            ..OrderCommand::default()
+        };
+        let mut buf = [0; ORDERCOMMANDSIZE];
+        encode_order_command(&command, &mut buf).unwrap();
+        buf
+    }
+
+    #[test]
+    fn rejects_every_short_buffer_without_panicking() {
+        for len in 0..ORDERCOMMANDSIZE {
+            assert!(
+                decode_order_command(&vec![0; len]).is_err(),
+                "buffer length {len} should be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn valid_message_round_trips() {
+        let decoded = decode_order_command(&encoded_command()).unwrap();
+
+        assert_eq!(decoded.command, OrderCommandType::CancelOrder);
+        assert_eq!(decoded.client_order_id, 11);
+        assert_eq!(decoded.order_id, 22);
+        assert_eq!(decoded.user_id, 33);
+        assert_eq!(decoded.market_id, 44);
+        assert_eq!(decoded.price, 55);
+        assert_eq!(decoded.size, 66);
+        assert_eq!(decoded.side, Side::Bid);
+        assert_eq!(decoded.time_in_force, TimeInForce::Fok);
+        assert_eq!(decoded.timestamp, 77);
+        assert_eq!(decoded.status, Status::Cancelled);
+    }
+
+    #[test]
+    fn rejects_invalid_sbe_header() {
+        for offset in [0, 2, 4] {
+            let mut buf = encoded_command();
+            buf[offset..offset + 2].copy_from_slice(&0_u16.to_le_bytes());
+
+            assert!(decode_order_command(&buf).is_err());
+        }
     }
 }


### PR DESCRIPTION
## The problem

`decode_order_command` was called directly on raw Aeron fragments with no length check
(`networking/src/server/cmd_handler.rs:13`), and the SBE accessors are raw slice indexes:

```rust
slice[index..index + N].try_into().expect("slice with incorrect length")   // order/src/lib.rs:80
```

Measured in a release build: **every buffer length from 0 to 63 panicked**; only 64 decoded. The
panic fires inside a callback invoked from Aeron's C poll loop through `rusteron`'s `extern "C"`
trampoline, and unwinding out of an `extern "C"` frame aborts the process.

The SBE header was also never validated in release — the only check was a `debug_assert_eq!` on the
template id (`order_command_message_codec.rs:267`), compiled out in release, and the schema id was
never read at all. Corrupting the first four bytes still decoded cleanly.

Combined with the unauthenticated gateway handshake (#114), this was a remote crash.

## The fix

A single guard at the decode boundary, before any field is read:

- reject buffers shorter than `ORDERCOMMANDSIZE`;
- reject headers whose `block_length`, `template_id` or `schema_id` are not the expected values.

Both return a descriptive `Err` through the function's existing error type, so every caller already
handles it — no call site changes and no `catch_unwind`.

This is three integer comparisons on the ingress hot path. The per-field accessors are deliberately
left as raw indexes: making them individually fallible would add a branch per field to every decode
for no additional safety once the boundary is checked.

## Cross-reference

`vex-gateway` has the identical construction on its side of the link, decoding engine responses with
no length check (trade-vex/vex-gateway#59). Because the codec is shared via the `common` crate, this
fix covers both directions.

## Verification

`cargo check` and `cargo clippy --workspace --all-targets` clean; `cargo test -p common -p sbe_order`
passes, with new tests asserting every length 0..63 returns `Err` without panicking, a valid message
round-trips, and a corrupted header is rejected.

Closes #115
