### PR TITLE
fix: reject a cancel that does not come from the order's owner

### DIFF
--- a/common/src/cmd.rs
+++ b/common/src/cmd.rs
@@ -46,14 +46,9 @@ pub struct OrderCommand {
     pub order_id: u64,
 
     /// The unique identifier of the user initiating the command.
-    /// For 'PlaceOrder' : This is the actual user id
-    /// For 'CancelOrder': this is set to the gateway id inside the OrderCommand Field
-    /// This is required because, in the existing scenarior the gateway id(required to send
-    /// back the response to gateway with gateway_id in the events handler) not present in
-    /// the OrderCommand Field, so it is encoded in the order_id by the snowflake algorithm
-    /// Everything works correctly untill the order_id is itself wrong that is sent the gateway
-    /// and user_id is not essential for the CancelOrder hence it is the best choice to place
-    /// gateway id to send response correctly.
+    /// For `PlaceOrder`, this is the owner of the new order.
+    /// For `CancelOrder`, this is the caller whose ownership of the existing order is checked.
+    /// Gateway response routing uses `route_gateway_id`, not this field.
     pub user_id: u64,
 
     /// The identifier for the market this command targets.
@@ -153,12 +148,12 @@ impl OrderCommand {
         }
     }
 
-    pub fn cancel_order(order_id: u64, side: Side, market_id: u32) -> Self {
+    pub fn cancel_order(order_id: u64, user_id: u64, side: Side, market_id: u32) -> Self {
         Self {
             command: OrderCommandType::CancelOrder,
             order_id,
             market_id,
-            user_id: 0,
+            user_id,
             price: 0,
             size: 0,
             side,

--- a/orderbook/src/lib.rs
+++ b/orderbook/src/lib.rs
@@ -70,23 +70,30 @@ impl PriceLevel {
 
     #[inline]
     fn remove_order(&mut self, order_id: u64, cmd: &mut OrderCommand) -> bool {
+        let requesting_user_id = cmd.user_id;
         if let Ok(pos) = self
             .orders
             .binary_search_by_key(&order_id, |order| order.order_id)
-            && let Some(removed_order) = self.orders.remove(pos)
         {
-            self.total_volume -= removed_order.size;
-            cmd.set_price(removed_order.price);
-            cmd.set_size(removed_order.size);
-            cmd.set_user_id(removed_order.user_id);
-            cmd.set_side(removed_order.side);
-            cmd.set_status(Status::Cancelled);
-            cmd.original_size = removed_order.original_size;
-            true
-        } else {
-            cmd.set_status(Status::Rejected);
-            false
+            if self.orders[pos].user_id != requesting_user_id {
+                cmd.set_status(Status::Rejected);
+                return false;
+            }
+
+            if let Some(removed_order) = self.orders.remove(pos) {
+                self.total_volume -= removed_order.size;
+                cmd.set_price(removed_order.price);
+                cmd.set_size(removed_order.size);
+                cmd.set_user_id(removed_order.user_id);
+                cmd.set_side(removed_order.side);
+                cmd.set_status(Status::Cancelled);
+                cmd.original_size = removed_order.original_size;
+                return true;
+            }
         }
+
+        cmd.set_status(Status::Rejected);
+        false
     }
 
     /// Get the total volume at this price level

--- a/orderbook/src/unit_tests.rs
+++ b/orderbook/src/unit_tests.rs
@@ -3649,4 +3649,98 @@ mod test {
         assert_eq!(snapshot.ask_prices[2], 103);
         assert_eq!(snapshot.ask_volumes[2], 35);
     }
+
+    #[test]
+    fn test_order_cancellation_rejects_non_owner_without_modifying_book() {
+        let (mut book, price_cache) = create_test_orderbook();
+
+        let mut place_cmd = create_order_command(
+            OrderCommandType::PlaceOrder,
+            1,
+            100,
+            1001,
+            1,
+            50,
+            100,
+            Side::Bid,
+            TimeInForce::Gtc,
+        );
+        book.place_order(&mut place_cmd, price_cache.clone());
+
+        let mut unauthorized_cancel = create_order_command(
+            OrderCommandType::CancelOrder,
+            1,
+            101,
+            2002,
+            1,
+            0,
+            0,
+            Side::Bid,
+            TimeInForce::Gtc,
+        );
+        book.cancel_order(&mut unauthorized_cancel, price_cache.clone());
+
+        assert_eq!(unauthorized_cancel.status(), Status::Rejected);
+        assert_eq!(book.get_volume_at_price(50, Side::Bid), 100);
+        assert_eq!(book.total_order_count(), 1);
+        assert!(book.verify_state().is_ok());
+
+        let mut owner_cancel = create_order_command(
+            OrderCommandType::CancelOrder,
+            1,
+            102,
+            1001,
+            1,
+            0,
+            0,
+            Side::Bid,
+            TimeInForce::Gtc,
+        );
+        book.cancel_order(&mut owner_cancel, price_cache.clone());
+
+        assert_eq!(owner_cancel.status(), Status::Cancelled);
+        assert_eq!(book.total_order_count(), 0);
+        assert_eq!(book.best_bid(), None);
+        assert!(book.verify_state().is_ok());
+    }
+
+    #[test]
+    fn test_order_cancellation_by_owner_still_succeeds() {
+        let (mut book, price_cache) = create_test_orderbook();
+
+        let mut place_cmd = create_order_command(
+            OrderCommandType::PlaceOrder,
+            2,
+            200,
+            3003,
+            1,
+            75,
+            125,
+            Side::Ask,
+            TimeInForce::Gtc,
+        );
+        book.place_order(&mut place_cmd, price_cache.clone());
+
+        let mut cancel_cmd = create_order_command(
+            OrderCommandType::CancelOrder,
+            2,
+            201,
+            3003,
+            1,
+            0,
+            0,
+            Side::Ask,
+            TimeInForce::Gtc,
+        );
+        book.cancel_order(&mut cancel_cmd, price_cache.clone());
+
+        assert_eq!(cancel_cmd.status(), Status::Cancelled);
+        assert_eq!(cancel_cmd.user_id, 3003);
+        assert_eq!(cancel_cmd.price, 75);
+        assert_eq!(cancel_cmd.size, 125);
+        assert_eq!(cancel_cmd.side, Side::Ask);
+        assert_eq!(book.total_order_count(), 0);
+        assert_eq!(book.best_ask(), None);
+        assert!(book.verify_state().is_ok());
+    }
 }

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -1403,7 +1403,7 @@ mod tests {
         // Maker C cancels their order of the remaining (20 - 5) BASE @ 1020
         let maker_c_order_id = placed_c.order_id; // Use the actual generated order ID
         producer.publish(|cmd| {
-            *cmd = OrderCommand::cancel_order(maker_c_order_id, Side::Ask, market_id);
+            *cmd = OrderCommand::cancel_order(maker_c_order_id, maker_c_id, Side::Ask, market_id);
         });
         let cancelled_c = rx.recv_timeout(Duration::from_secs(1)).unwrap();
         assert_eq!(cancelled_c.status, Status::Cancelled);
@@ -1865,7 +1865,12 @@ mod tests {
         // --- Phase 5: Final Clean-up and State Verification ---
         // Bob cancels his resting GTC ask on BTC/USD
         producer.publish(|cmd| {
-            *cmd = OrderCommand::cancel_order(bob_gtc_order_id, Side::Ask, market_btc_usd)
+            *cmd = OrderCommand::cancel_order(
+                bob_gtc_order_id,
+                bob_taker_id,
+                Side::Ask,
+                market_btc_usd,
+            )
         });
         let cancelled_bob = rx.recv().unwrap();
         assert_eq!(cancelled_bob.status, Status::Cancelled);

--- a/xtask/src/builders/order_builder.rs
+++ b/xtask/src/builders/order_builder.rs
@@ -40,8 +40,8 @@ impl OrderBuilder {
     }
 
     /// Create a cancel order builder
-    pub fn cancel() -> CancelBuilder<NeedsOrderId> {
-        CancelBuilder::new()
+    pub fn cancel(user_id: u64) -> CancelBuilder<NeedsOrderId> {
+        CancelBuilder::new(user_id)
     }
 }
 
@@ -637,15 +637,17 @@ pub struct NeedsOrderId;
 
 pub struct CancelBuilder<State = NeedsOrderId> {
     order_id: u64,
+    user_id: u64,
     side: Side,
     market_id: u32,
     _state: std::marker::PhantomData<State>,
 }
 
 impl CancelBuilder<NeedsOrderId> {
-    fn new() -> Self {
+    fn new(user_id: u64) -> Self {
         Self {
             order_id: 0,
+            user_id,
             side: Side::Bid,
             market_id: 0,
             _state: std::marker::PhantomData,
@@ -655,6 +657,7 @@ impl CancelBuilder<NeedsOrderId> {
     pub fn order_id(self, order_id: u64) -> CancelBuilder<NeedsSide> {
         CancelBuilder {
             order_id,
+            user_id: self.user_id,
             side: self.side,
             market_id: self.market_id,
             _state: std::marker::PhantomData,
@@ -666,6 +669,7 @@ impl CancelBuilder<NeedsSide> {
     pub fn side(self, side: Side) -> CancelBuilder<NeedsMarket> {
         CancelBuilder {
             order_id: self.order_id,
+            user_id: self.user_id,
             side,
             market_id: self.market_id,
             _state: std::marker::PhantomData,
@@ -677,6 +681,7 @@ impl CancelBuilder<NeedsMarket> {
     pub fn market_id(self, market_id: u32) -> CancelBuilder<Complete> {
         CancelBuilder {
             order_id: self.order_id,
+            user_id: self.user_id,
             side: self.side,
             market_id,
             _state: std::marker::PhantomData,
@@ -686,6 +691,6 @@ impl CancelBuilder<NeedsMarket> {
 
 impl CancelBuilder<Complete> {
     pub fn build(self) -> OrderCommand {
-        OrderCommand::cancel_order(self.order_id, self.side, self.market_id)
+        OrderCommand::cancel_order(self.order_id, self.user_id, self.side, self.market_id)
     }
 }

--- a/xtask/src/scenarios/cancellation.rs
+++ b/xtask/src/scenarios/cancellation.rs
@@ -362,7 +362,7 @@ async fn cancel_resting_bid_section(ctx: &mut TestContext) -> TestResult<()> {
     }
 
     // Cancel the order
-    let cancel_cmd = OrderBuilder::cancel()
+    let cancel_cmd = OrderBuilder::cancel(users::ALICE)
         .order_id(order_id)
         .side(Side::Bid)
         .market_id(market_id)
@@ -461,7 +461,7 @@ async fn cancel_resting_ask_section(ctx: &mut TestContext) -> TestResult<()> {
     }
 
     // Cancel the order
-    let cancel_cmd = OrderBuilder::cancel()
+    let cancel_cmd = OrderBuilder::cancel(users::BOB)
         .order_id(order_id)
         .side(Side::Ask)
         .market_id(market_id)
@@ -620,7 +620,7 @@ async fn cancel_partially_filled_section(ctx: &mut TestContext) -> TestResult<()
     }
 
     // Cancel Charlie's remaining order
-    let cancel_cmd = OrderBuilder::cancel()
+    let cancel_cmd = OrderBuilder::cancel(users::CHARLIE)
         .order_id(charlie_order_id)
         .side(Side::Bid)
         .market_id(market_id)
@@ -674,7 +674,7 @@ async fn cancel_nonexistent_order_section(ctx: &mut TestContext) -> TestResult<(
     let fake_order_id = 999999;
 
     // Try to cancel non-existent order
-    let cancel_cmd = OrderBuilder::cancel()
+    let cancel_cmd = OrderBuilder::cancel(users::ALICE)
         .order_id(fake_order_id)
         .side(Side::Bid)
         .market_id(market_id)
@@ -760,7 +760,7 @@ async fn cancel_filled_order_section(ctx: &mut TestContext) -> TestResult<()> {
     }
 
     // Try to cancel Bob's already filled order
-    let cancel_cmd = OrderBuilder::cancel()
+    let cancel_cmd = OrderBuilder::cancel(users::BOB)
         .order_id(bob_order_id)
         .side(Side::Ask)
         .market_id(market_id)
@@ -832,7 +832,7 @@ async fn cancel_and_replace_section(ctx: &mut TestContext) -> TestResult<()> {
     }
 
     // Cancel first order
-    let cancel_cmd = OrderBuilder::cancel()
+    let cancel_cmd = OrderBuilder::cancel(users::ALICE)
         .order_id(order_id1)
         .side(Side::Bid)
         .market_id(market_id)
@@ -983,7 +983,7 @@ async fn multiple_cancellations_section(ctx: &mut TestContext) -> TestResult<()>
     }
 
     // Cancel order 1
-    let cancel1 = OrderBuilder::cancel()
+    let cancel1 = OrderBuilder::cancel(users::BOB)
         .order_id(order_id1)
         .side(Side::Ask)
         .market_id(market_id)
@@ -994,7 +994,7 @@ async fn multiple_cancellations_section(ctx: &mut TestContext) -> TestResult<()>
     tokio::time::sleep(Duration::from_millis(150)).await;
 
     // Cancel order 2
-    let cancel2 = OrderBuilder::cancel()
+    let cancel2 = OrderBuilder::cancel(users::BOB)
         .order_id(order_id2)
         .side(Side::Ask)
         .market_id(market_id)
@@ -1005,7 +1005,7 @@ async fn multiple_cancellations_section(ctx: &mut TestContext) -> TestResult<()>
     tokio::time::sleep(Duration::from_millis(150)).await;
 
     // Cancel order 3
-    let cancel3 = OrderBuilder::cancel()
+    let cancel3 = OrderBuilder::cancel(users::BOB)
         .order_id(order_id3)
         .side(Side::Ask)
         .market_id(market_id)

--- a/xtask/src/scenarios/comprehensive.rs
+++ b/xtask/src/scenarios/comprehensive.rs
@@ -637,7 +637,7 @@ async fn cancellations_during_trading_section(ctx: &mut TestContext) -> TestResu
     tokio::time::sleep(Duration::from_millis(200)).await;
 
     // Charlie cancels it
-    let cancel1 = OrderBuilder::cancel()
+    let cancel1 = OrderBuilder::cancel(users::CHARLIE)
         .order_id(charlie_order_id)
         .side(Side::Ask)
         .market_id(market_id)
@@ -680,7 +680,7 @@ async fn cancellations_during_trading_section(ctx: &mut TestContext) -> TestResu
 
     tokio::time::sleep(Duration::from_millis(150)).await;
 
-    let cancel2 = OrderBuilder::cancel()
+    let cancel2 = OrderBuilder::cancel(users::BOB)
         .order_id(bob_order_id)
         .side(Side::Bid)
         .market_id(market_id)
@@ -994,7 +994,7 @@ async fn partial_fills_with_cancel_section(ctx: &mut TestContext) -> TestResult<
     }
 
     // Alice cancels remaining order
-    let cancel = OrderBuilder::cancel()
+    let cancel = OrderBuilder::cancel(users::ALICE)
         .order_id(alice_order_id)
         .side(Side::Bid)
         .market_id(market_id)


### PR DESCRIPTION
## The problem

`cancel_order` cancelled any order id it was given, with no check that the requester owned it.
Worse, `PriceLevel::remove_order` **overwrote** the requester with the resting order's owner:

```rust
cmd.set_user_id(removed_order.user_id);   // orderbook/src/lib.rs:80
```

so Risk R2 then refunded the *victim* — which made an unauthorised cancel look legitimate all the
way downstream. Order ids are structurally predictable (`timestamp << 16 | sequence << 4 | gateway`),
so guessing a live id is not hard.

## The fix

Compare before mutating. The requesting user is already on the command — the gateway sets
`OrderCommand.user_id` to the authenticated user when it builds a `CancelOrder` — so the book only
needed to check it instead of discarding it:

- `PriceLevel::remove_order` now compares `cmd.user_id` against the resting order's owner and
  rejects on mismatch, leaving the level, the volume and the order untouched.
- `OrderBook::cancel_order` no longer removes the `orders` index entry up front; it removes it only
  once the cancel has actually succeeded. Previously a failed lookup dropped the index entry and
  orphaned the order permanently.

`remove_order` is private, so returning `bool` is not an API change. On the success path
`set_user_id` is now a no-op (requester == owner) and is left in place so the R2 sharding and refund
behaviour are byte-for-byte unchanged.

The check is one integer comparison with no allocation, and the removal is written without `unwrap`
so it adds no panic site to the matching thread.

## Correction: the requester was not on every cancel

The paragraph above — "the requesting user is already on the command" — was true of the gateway and
of nothing else, and this PR now carries a second commit to fix that.

The gateway's handler does populate the field from the authenticated identity
(`crates/libs/lib-api/src/handlers/order.rs`). But `OrderCommand::cancel_order`, the constructor
every in-repo caller uses, hardcoded it:

```rust
pub fn cancel_order(order_id: u64, side: Side, market_id: u32) -> Self {
    Self { /* ... */ user_id: 0, /* ... */ }
}
```

and the field's own doc comment described `user_id` on a `CancelOrder` as deliberately holding a
*gateway* id — "user_id is not essential for the CancelOrder hence it is the best choice to place
gateway id to send response correctly". The ownership guard turns that field from an output into a
**required input**, so every cancel constructed inside this repo arrived with `user_id = 0` and was
rejected as a third-party cancel:

```
event="command_processed" … user_id=0 command=CancelOrder status=Rejected stage="events"
```

`cargo check` and clippy were silent about it — `user_id: 0` is perfectly well-typed — so the
follow-up makes `user_id` a **positional argument** on `cancel_order` rather than something a caller
can forget. That converts every stale call site from a runtime rejection into a compile error, which
is the only reliable way to find them all. There were more than expected:

- `server/src/lib.rs` — 2 sites, both in tests that were already failing (see Verification).
- `xtask/src/scenarios/cancellation.rs` — 9 sites; `xtask/src/scenarios/comprehensive.rs` — 3 sites.
  `xtask`'s typestate `CancelBuilder` had no `user_id` field at all, so `OrderBuilder::cancel()` now
  takes the caller and threads it through each state transition to `build()`.

This is not a wire or protocol change: `user_id` was already on `OrderCommand` and the gateway was
already filling it in. What changed is the in-repo constructor, its callers, and the doc comment,
which now states what the field means — owner on a place, caller on a cancel — and points response
routing at `route_gateway_id`, which is a separate field and always was.

## Cross-reference

The gateway does not check ownership either (trade-vex/vex-gateway#53). The engine is the right
place for the authoritative check: the order book is the only component with synchronous truth about
who owns a resting order. The gateway's own view is populated asynchronously from Kafka, so a
gateway-side pre-check would reject legitimate cancels of just-placed orders while adding nothing
this fix does not already guarantee.

## Verification

The verification originally claimed here stopped at `cargo test -p vex-orderbook`, and that was not
enough. On the guard commit alone, `cargo test -p vex-server --lib` failed in both tests that cancel
an order:

```
thread 'tests::test_multi_market_stress_scenario' panicked at server/src/lib.rs:1778:9:
assertion `left == right` failed
  left: Rejected
 right: Cancelled

failures:
    tests::test_complex_scenario_with_cancellations_and_mixed_tif
    tests::test_multi_market_stress_scenario

test result: FAILED. 5 passed; 2 failed
```

Both of those tests cancel an order they placed themselves, so both are legitimate owner cancels;
they were rejected purely because the constructor supplied `user_id = 0`. Passing the caller in
fixes them without touching either assertion's expectation.

On the head of this branch:

- `cargo test -p vex-orderbook` — 75 passed, 0 failed, including new cases asserting a third-party
  cancel is rejected with the order still on the book and still cancellable by its true owner.
- `cargo test -p vex-server --lib` — 7 passed, 0 failed.
- `cargo clippy --workspace --all-targets` — 0 warnings.

Closes #121
