### PR TITLE
fix: handle SIGTERM so orchestrated restarts drain gracefully

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tracing = "0.1"
 tracing-subscriber = "0.3"
-ctrlc = "3.4"
+ctrlc = { version = "3.4", features = ["termination"] }
 parking_lot = "0.12"
 tikv-jemallocator = "0.5"
 

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -31,7 +31,7 @@ tracing = { workspace = true }
 disruptor = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-ctrlc = "3.4"
+ctrlc = { version = "3.4", features = ["termination"] }
 tikv-jemallocator = { workspace = true }
 redis = { version = "0.27", features = ["aio", "tokio-comp", "connection-manager"] }
 tokio = { version = "1", features = ["full"] }


### PR DESCRIPTION
## The problem

`ctrlc` was declared without the `termination` feature:

```toml
ctrlc = "3.4"          # Cargo.toml
```

Without it the crate installs a handler for **SIGINT only**. `docker compose down`, Kubernetes
rolling restarts and `systemctl stop` all send SIGTERM, so the process was killed instantly
mid-pipeline — commands already journaled to the Aeron archive but not yet settled by Risk R2 were
left mid-transaction, and Kafka events for completed work were never flushed.

`RUNBOOK.md` documents `kill -TERM` as the graceful stop, so the documented procedure did not work.

## The fix

Enable the `termination` feature so SIGTERM (and SIGHUP) reach the handler that is already
installed at `src/main.rs:100`. No new code, no new dependency, no new configuration — the existing
shutdown path, which sets the flag consumed by the Aeron poll loop at
`networking/src/server/mod.rs:238`, now runs for the signal orchestrators actually send.

`xtask` declared `ctrlc` separately and is updated to match so the two do not diverge.

## Verification

`cargo check` and `cargo clippy --workspace --all-targets` clean. `cargo tree -e features -p ctrlc`
confirms the resolved tree now pulls `nix feature "signal"`, i.e. the termination handler is
compiled in.

Closes #137
