### PR TITLE
fix: never let an order rest at a market-order sentinel price

### DIFF
--- a/orderbook/src/lib.rs
+++ b/orderbook/src/lib.rs
@@ -239,15 +239,18 @@ impl<Ask: BookSide, Bid: BookSide> OrderBook<Ask, Bid> {
             TimeInForce::Gtc => {
                 // Handle GTC (Good 'Til Canceled) orders
                 let remaining = self.match_order(cmd);
-                if remaining == cmd.size {
-                    self.add_to_book(cmd, remaining);
-                    cmd.set_status(Status::Placed);
-                } else if remaining > 0 {
-                    // Add remaining to book
-                    self.add_to_book(cmd, remaining);
-                    cmd.set_status(Status::PartiallyFilled);
-                } else {
+                if remaining == 0 && cmd.size != 0 {
                     cmd.set_status(Status::Filled);
+                } else if Self::is_market_order(cmd) {
+                    cmd.set_status(Status::Cancelled);
+                } else if self.add_to_book(cmd, remaining) {
+                    cmd.set_status(if remaining == cmd.size {
+                        Status::Placed
+                    } else {
+                        Status::PartiallyFilled
+                    });
+                } else {
+                    cmd.set_status(Status::Cancelled);
                 }
                 cmd.set_size(remaining);
             }
@@ -347,7 +350,11 @@ impl<Ask: BookSide, Bid: BookSide> OrderBook<Ask, Bid> {
     }
 
     /// Add order to the book
-    fn add_to_book(&mut self, cmd: &OrderCommand, remaining_size: u64) {
+    fn add_to_book(&mut self, cmd: &OrderCommand, remaining_size: u64) -> bool {
+        if cmd.price == 0 || cmd.price == u64::MAX {
+            return false;
+        }
+
         let order = Order {
             order_id: cmd.order_id,
             user_id: cmd.user_id,
@@ -365,6 +372,7 @@ impl<Ask: BookSide, Bid: BookSide> OrderBook<Ask, Bid> {
         };
         level.add_order(order);
         self.orders.insert(cmd.order_id, cmd.price);
+        true
     }
 
     /// Check if an order can be filled completely

--- a/orderbook/src/unit_tests.rs
+++ b/orderbook/src/unit_tests.rs
@@ -368,6 +368,113 @@ mod test {
     }
 
     #[test]
+    fn test_gtc_market_sell_on_empty_book_is_cancelled_without_resting() {
+        let (mut book, price_cache) = create_test_orderbook();
+        let mut cmd = create_order_command(
+            OrderCommandType::PlaceOrder,
+            1,
+            100,
+            1001,
+            1,
+            0,
+            100,
+            Side::Ask,
+            TimeInForce::Gtc,
+        );
+
+        book.place_order(&mut cmd, price_cache);
+
+        assert_eq!(cmd.status(), Status::Cancelled);
+        assert_eq!(cmd.size(), 100);
+        assert_eq!(book.get_level_order_count(Side::Ask, 0), 0);
+        assert_eq!(book.best_ask(), None);
+        assert_eq!(book.total_order_count(), 0);
+    }
+
+    #[test]
+    fn test_gtc_limit_order_still_rests_with_sentinel_guard() {
+        let (mut book, price_cache) = create_test_orderbook();
+        let mut cmd = create_order_command(
+            OrderCommandType::PlaceOrder,
+            1,
+            100,
+            1001,
+            1,
+            55,
+            100,
+            Side::Ask,
+            TimeInForce::Gtc,
+        );
+
+        book.place_order(&mut cmd, price_cache);
+
+        assert_eq!(cmd.status(), Status::Placed);
+        assert_eq!(cmd.size(), 100);
+        assert_eq!(book.best_ask(), Some((55, 100)));
+        assert_eq!(book.total_order_count(), 1);
+    }
+
+    #[test]
+    fn test_gtc_opposite_side_sentinel_price_does_not_rest() {
+        let (mut book, price_cache) = create_test_orderbook();
+        let mut cmd = create_order_command(
+            OrderCommandType::PlaceOrder,
+            1,
+            100,
+            1001,
+            1,
+            0,
+            100,
+            Side::Bid,
+            TimeInForce::Gtc,
+        );
+
+        book.place_order(&mut cmd, price_cache);
+
+        assert_eq!(cmd.status(), Status::Cancelled);
+        assert_eq!(cmd.size(), 100);
+        assert_eq!(book.get_level_order_count(Side::Bid, 0), 0);
+        assert_eq!(book.best_bid(), None);
+        assert_eq!(book.total_order_count(), 0);
+    }
+
+    #[test]
+    fn test_ioc_and_fok_market_sell_behaviour_is_unchanged() {
+        let (mut book, price_cache) = create_test_orderbook();
+        let mut ioc_cmd = create_order_command(
+            OrderCommandType::PlaceOrder,
+            1,
+            100,
+            1001,
+            1,
+            0,
+            100,
+            Side::Ask,
+            TimeInForce::Ioc,
+        );
+        let mut fok_cmd = create_order_command(
+            OrderCommandType::PlaceOrder,
+            2,
+            101,
+            1002,
+            1,
+            0,
+            100,
+            Side::Ask,
+            TimeInForce::Fok,
+        );
+
+        book.place_order(&mut ioc_cmd, price_cache.clone());
+        book.place_order(&mut fok_cmd, price_cache);
+
+        assert_eq!(ioc_cmd.status(), Status::Cancelled);
+        assert_eq!(ioc_cmd.size(), 100);
+        assert_eq!(fok_cmd.status(), Status::Cancelled);
+        assert_eq!(fok_cmd.size(), 100);
+        assert_eq!(book.total_order_count(), 0);
+    }
+
+    #[test]
     fn test_multiple_orders_same_price_level() {
         let (mut book, price_cache) = create_test_orderbook();
 


### PR DESCRIPTION
## The problem

Two reachable paths let an order come to rest at a market-order sentinel price, after which a
counterparty's position was taken for zero consideration. Both were reproduced against the real
engine.

**A GTC "market" order rested.** Nothing required a market order to be IOC/FOK, so the GTC arm
called `add_to_book(cmd, remaining)` with `cmd.price` still the sentinel. The compensating rewrite
at `lib.rs:283-289` only runs when something filled, so an unfilled market sell rested at price 0
and became the best ask:

```
GTC 'market' SELL x100 -> Placed (rests at price 0)
BID @1000 x100 -> Filled, fill: 100 units @ price 0
seller: BASE 1000 -> 900, QUOTE 0 -> 0
```

**A limit BID at price 0 rested for free.** The ASK-side crossing predicate is
`taker_price <= maker_price`, true for every price including 0, so an ordinary market sell swept
down to it:

```
attacker (zero balance) bid@0 x1000 -> Placed, quote locked 0
victim market-sell x1000 -> Filled, fill: 1000 units @ price 0
attacker BASE 1000, QUOTE 0    <- paid nothing, took the victim's position
```

## The fix

Two guards, both in the order book:

- In the GTC arm, a market order's unfilled remainder is **cancelled** rather than added to the
  book. Cancelling (rather than rejecting up front) is the smaller change and keeps the funds
  accounting correct: `Status::Cancelled` with `cmd.size = remaining` is exactly what the Risk R2
  matrix at `server/src/utils.rs:108-115` already matches on, so `handle_cancellation` releases the
  unfilled remainder. Any fills that did occur are still settled from the attached event chain.
- `add_to_book` refuses a sentinel price at the single insertion point and reports it, so a
  sentinel can never enter the book regardless of how it is reached. This is what closes the
  limit-bid-at-zero path, which is not a market order by `is_market_order`'s definition.

A market BUY is unaffected in practice: Risk R1 has already rewritten its price to a concrete
slippage-capped value before the book sees it, so it rests as an ordinary limit order at that price.

IOC and FOK behaviour is untouched — those are separate match arms.

## Cross-reference

`vex-gateway` accepts both shapes — `order_type` and `time_in_force` are independent unvalidated
fields, and a `Limit` order may carry a sentinel price (trade-vex/vex-gateway#49). This engine-side
guard holds regardless of what upstream sends.

## Verification

`cargo check` and `cargo clippy --workspace --all-targets` clean; `cargo test -p vex-orderbook -p
processors` passes 91 tests, including new cases for a GTC market sell against an empty book, a
limit order still resting normally, and unchanged IOC/FOK behaviour.

Closes #112
