### PR TITLE
fix: make the Docker image build and actually run

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,5 @@
 target/
 !target/generated/
-Cargo.lock
 .cargo/
 .gitignore
 README.md

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,9 +39,9 @@ borsh = { version = "1.5.7", default-features = false, features = ["hashbrown", 
 tokio = { version = "1", features = ["full"] }
 hashbrown = { version = "0.15.4", features = ["serde"]}
 thiserror = "2.0.12"
-rusteron-client = "0.1.143"
-rusteron-media-driver = "0.1.143"
-rusteron-archive = "0.1.143"
+rusteron-client = "=0.1.157"
+rusteron-media-driver = "=0.1.157"
+rusteron-archive = "=0.1.157"
 disruptor = {git="https://github.com/trade-vex/disruptor-rs.git" , rev="19ef2a9"}
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,24 @@
 # Multi-stage build for Rust application
-FROM rust:latest as builder
+FROM rust:1-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y \
+    curl \
     pkg-config \
     libssl-dev \
+    uuid-dev \
+    ca-certificates \
+    make \
+    gcc \
+    g++ \
+    clang \
+    zlib1g-dev \
+    libbsd-dev \
+    python3-pip \
+    default-jdk \
+    protobuf-compiler \
+    && pip3 install cmake --upgrade --break-system-packages \
+    && rustup component add rustfmt \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
@@ -15,12 +29,25 @@ COPY . .
 # Build the application
 RUN cargo build --release
 
+# Collect the Aeron shared libraries produced by the rusteron build scripts.
+RUN mkdir -p /app/runtime-libs \
+    && find /app/target/release -type f \
+        \( -name 'libaeron.so' \
+        -o -name 'libaeron_driver.so' \
+        -o -name 'libaeron_archive_c_client.so' \) \
+        -exec cp -v -t /app/runtime-libs {} + \
+    && test -f /app/runtime-libs/libaeron.so \
+    && test -f /app/runtime-libs/libaeron_driver.so \
+    && test -f /app/runtime-libs/libaeron_archive_c_client.so
+
 # Runtime stage
 FROM debian:bookworm-slim
 
 # Install runtime dependencies
 RUN apt-get update && apt-get install -y \
     libssl3 \
+    libbsd0 \
+    zlib1g \
     ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
@@ -28,6 +55,8 @@ WORKDIR /app
 
 # Copy the built binary
 COPY --from=builder /app/target/release/vex-core /usr/local/bin/vex-core
+COPY --from=builder /app/runtime-libs/ /usr/local/lib/
+RUN ldconfig
 
 # Create shared volume for Aeron IPC
 VOLUME ["/tmp/aeron"]


### PR DESCRIPTION
## The problem

`docker build .` failed from a clean checkout, and once that was fixed the image still could not
start. Three independent defects:

**1. `Cargo.lock` was excluded from the build context.** `.dockerignore:1` listed it, and
`rusteron-* = "0.1.143"` is a caret range, so a fresh resolve inside the image picked the newest
`0.1.x` while the committed lock pins `0.1.157`.
`AeronArchiveContext::new_with_no_credentials_supplier` — called at
`networking/src/server/mod.rs:347` — exists in 0.1.157 and was **removed by 0.1.168**:

```
rusteron-archive 0.1.157: symbol PRESENT
rusteron-archive 0.1.168: symbol ABSENT
error[E0599]: no function or associated item named `new_with_no_credentials_supplier`
```

**2. The builder stage lacked build dependencies.** It installed only `pkg-config` and `libssl-dev`,
while `processors/build.rs` needs `protoc` and `rusteron-archive`'s build script needs cmake and a
JDK — the set CI already installs.

**3. The image could not run even once it built.** Verified by running it:

```
$ docker run --rm --entrypoint /bin/sh <image> -c 'ldd /usr/local/bin/vex-core'
/usr/local/bin/vex-core: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found
    libaeron_driver.so => not found
    libbsd.so.0 => not found
    libaeron_archive_c_client.so => not found
    libaeron.so => not found

$ docker run --rm <image>
vex-core: error while loading shared libraries: libaeron_driver.so: cannot open shared object file
```

The builder was `rust:latest` (Debian trixie, glibc ≥ 2.38) against a `bookworm-slim` runtime
(glibc 2.36), and Aeron is **not** statically linked — `rusteron` produces three shared objects that
were never copied.

## The fix

- Stop excluding `Cargo.lock` so the image builds the locked dependency set.
- Pin `rusteron-{client,media-driver,archive}` to `=0.1.157` so a caret range can never again select
  an incompatible `0.1.x`.
- Mirror CI's build dependencies in the builder stage.
- Use `rust:1-bookworm` so the binary links against the same glibc the runtime provides (and fix the
  `FromAsCasing` warning).
- Copy the three Aeron shared objects out of the builder, install `libbsd0` and `zlib1g`, and run
  `ldconfig`.

`.cargo/` stays excluded — it holds only an `xtask` alias that the image does not use.

The `HEALTHCHECK` is deliberately untouched; it is broken for a different reason and tracked in #130.

## Verification

Real `docker build .` from this branch: **exit 0**. Then, on the produced image:

```
$ ldd /usr/local/bin/vex-core      -> no "not found", no GLIBC error
$ ls /usr/local/lib | grep aeron   -> libaeron.so  libaeron_archive_c_client.so  libaeron_driver.so
$ docker run --rm <image>
   INFO vex_core: Loaded configuration for environment: test
   INFO server_main: action="config_validated"
   INFO vex_server::engine: Added symbol to MatchingEngine shard symbol_id=65538
```

The binary starts, validates config and initialises the matching engine. It then stops on absent
Kafka and Aeron media-driver services, which is expected in a bare container.

## Cross-reference

`vex-gateway` resolves `rusteron 0.1.154` from the same caret range while this repo now pins
`0.1.157`, and both processes attach to the same media driver through a shared `context_dir`
(trade-vex/vex-gateway#76). Pinning both to the same version is the follow-up.

Closes #117


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Updated the application’s underlying components to a newer version for improved compatibility and reliability.
  - Enhanced container builds with required compilation tools and runtime libraries.
  - Improved packaging and validation of native runtime libraries for more consistent deployments.

- **Chores**
  - Refined container configuration and build settings while preserving the existing application entrypoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->