### PR TITLE
fix: make fee arithmetic overflow-safe and bound the fee configuration

### DIFF
--- a/processors/src/risk_engine.rs
+++ b/processors/src/risk_engine.rs
@@ -242,8 +242,9 @@ impl RiskEngine {
             Side::Bid => {
                 let quote_spent = spec.calculate_quote_cost(event.price, event.size);
                 // Fee is on the base asset received. Assuming fee is in basis points (e.g., 20bp = 0.2%)
-                let fee_in_base = (event.size * fee) / 10000;
-                let base_received_net = event.size - fee_in_base;
+                let fee_in_base =
+                    u64::try_from((event.size as u128 * fee as u128) / 10000).unwrap_or(u64::MAX);
+                let base_received_net = event.size.saturating_sub(fee_in_base);
                 (
                     quote_asset(market_id),
                     quote_spent,
@@ -257,8 +258,10 @@ impl RiskEngine {
                 let base_spent = event.size;
                 let quote_received_gross = spec.calculate_quote_cost(event.price, event.size);
                 // Fee is on the quote asset received. Assuming fee is in basis points.
-                let fee_in_quote = (quote_received_gross * fee) / 10000;
-                let quote_received_net = quote_received_gross - fee_in_quote;
+                let fee_in_quote =
+                    u64::try_from((quote_received_gross as u128 * fee as u128) / 10000)
+                        .unwrap_or(u64::MAX);
+                let quote_received_net = quote_received_gross.saturating_sub(fee_in_quote);
                 (
                     base_asset(market_id),
                     base_spent,
@@ -1056,6 +1059,43 @@ mod tests {
             ],
             balances_before
         );
+    }
+
+    #[test]
+    fn test_trade_settlement_fee_at_18_decimal_scale() {
+        let base_asset_id = 2u16;
+        let quote_asset_id = 1u16;
+        let market_id = ((quote_asset_id as u32) << 16) | base_asset_id as u32;
+        let user_id = 102;
+        let price = 1;
+        let size = 1_000_000_000_000_000_000;
+
+        let mut specs = HashMap::new();
+        specs.insert(market_id, get_spec(market_id));
+        let engine = RiskEngine::new(specs, 0, 1);
+        engine.set_balance(user_id, quote_asset_id, UserBalance::new(0, size));
+
+        let mut trade_event = MatcherTradeEvent {
+            price,
+            size,
+            maker_user_id: 101,
+            active_order_completed: false,
+            matched_order_id: 1,
+            matched_order_completed: true,
+            next_event: None,
+            maker_balance: [UserBalance::default(); 2],
+            maker_remaining_size: 0,
+            maker_original_size: size,
+        };
+
+        engine.handle_trade_event(user_id, market_id, Side::Bid, &mut trade_event, Some(price));
+
+        let expected_fee = 2_000_000_000_000_000;
+        assert_eq!(
+            engine.get_balance(user_id, base_asset_id).total(),
+            size - expected_fee
+        );
+        assert_eq!(engine.get_balance(user_id, quote_asset_id).total(), 0);
     }
 
     #[test]

--- a/vex-config/src/symbols.rs
+++ b/vex-config/src/symbols.rs
@@ -214,6 +214,20 @@ impl SymbolSpecificationConfig {
             }
 
             // Validate fees
+            if spec.taker_fee >= 10000 {
+                return Err(ConfigError::ValidationError(format!(
+                    "Symbol {}: taker_fee ({}) must be less than 10000 basis points",
+                    market_id, spec.taker_fee
+                )));
+            }
+
+            if spec.maker_fee >= 10000 {
+                return Err(ConfigError::ValidationError(format!(
+                    "Symbol {}: maker_fee ({}) must be less than 10000 basis points",
+                    market_id, spec.maker_fee
+                )));
+            }
+
             if spec.taker_fee < spec.maker_fee {
                 return Err(ConfigError::ValidationError(format!(
                     "Symbol {}: taker_fee ({}) should be >= maker_fee ({})",
@@ -371,5 +385,21 @@ mod tests {
 
         let config = SymbolSpecificationConfig { symbols };
         assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn test_validation_rejects_fee_at_100_percent() {
+        let mut config = SymbolSpecificationConfig::development_defaults();
+        let spec = config.symbols.values_mut().next().unwrap();
+        let market_id = spec.market_id;
+        spec.taker_fee = 10000;
+
+        assert!(matches!(
+            config.validate(),
+            Err(ConfigError::ValidationError(message))
+                if message == format!(
+                    "Symbol {market_id}: taker_fee (10000) must be less than 10000 basis points"
+                )
+        ));
     }
 }


### PR DESCRIPTION
## The problem

Two defects in the same pair of lines in `settle_trade`, on both the Bid and Ask arms:

```rust
let fee_in_base = (event.size * fee) / 10000;      // bare u64 multiply
let base_received_net = event.size - fee_in_base;  // bare u64 subtract
```

**Overflow.** For an 18-decimal base asset one unit is `size = 1e18`, and `1e18 * 20 = 2e19` exceeds
`u64::MAX` (1.845e19). The release profile has `overflow-checks` off, so it wrapped:

| size | fee | correct fee | actual fee (release) |
|---|---|---|---|
| 1e18 | 20bp | 2,000,000,000,000,000 | 155,325,592,629,044 |

**92.2% of the fee silently lost.** In debug it panicked instead, which wedges the pipeline.

**Underflow.** `size - fee_in_base` had no upper bound on the fee. `validate()` only checked
`taker_fee >= maker_fee`, so `taker_fee = 20000` — a plausible "2%" typo — made `fee > size`:

```
size=1000 taker_fee=20000bp -> fee_in_base=2000 > size -> net = 18446744073709550616
```

## The fix

- Compute both fee amounts through `u128` and narrow back saturating, matching the idiom already
  used by `calculate_quote_cost`. The multiply can no longer wrap.
- Make the net-amount subtraction saturating, so it cannot underflow even if a fee were somehow
  out of range.
- Reject `taker_fee >= 10000` and `maker_fee >= 10000` in `vex-config`'s `validate()`, in the style
  of the existing checks. This is a bound on an existing field, not a new setting.

Fee semantics are unchanged — still basis points, still floor division.

## Note

This makes the fee *correct*; it does not change where the fee goes. Fees are still deducted from
the credited amount and credited to no account, so total supply still shrinks on every trade. That
is tracked separately in #118.

## Verification

`cargo check` and `cargo clippy --workspace --all-targets` clean; `cargo test -p processors -p common
-p vex-config` passes 69 tests, including a new settlement test at 18-decimal scale asserting the
mathematically correct fee rather than the wrapped one, and a config test rejecting a fee at the
10000bp boundary.

Closes #119
