### PR TITLE
fix: reject orders instead of dropping them when the ring buffer is full

### DIFF
--- a/networking/src/server/cmd_handler.rs
+++ b/networking/src/server/cmd_handler.rs
@@ -1,11 +1,14 @@
+use crate::server::gateway_publications::Publications;
 use common::{OrderCommand, Status, decode_order_command};
 use disruptor::{MultiProducer, Producer, SingleConsumerBarrier};
 use rusteron_archive::{AeronFragmentHandlerCallback, AeronHeader};
+use std::sync::Arc;
 use tracing::{debug, error, info};
 
 pub struct FragmentHandler {
     pub gateway_id: u8,
     pub producer: MultiProducer<OrderCommand, SingleConsumerBarrier>,
+    pub publications: Arc<Publications>,
 }
 
 impl AeronFragmentHandlerCallback for FragmentHandler {
@@ -30,6 +33,8 @@ impl AeronFragmentHandlerCallback for FragmentHandler {
                         error = %e,
                         "failed to publish order command to ring buffer"
                     );
+                    order_command.status = Status::Rejected;
+                    self.publications.publish_response(&order_command);
                 }
             }
             Err(e) => {

--- a/networking/src/server/duologue.rs
+++ b/networking/src/server/duologue.rs
@@ -1,15 +1,23 @@
 use crate::server::cmd_handler::FragmentHandler;
 use crate::server::gateway_manager::GatewaySessionEvent;
+use crate::server::gateway_publications::Publications;
 use common::OrderCommand;
 use disruptor::{MultiProducer, SingleConsumerBarrier};
 use rusteron_archive::{
     AeronAvailableImageCallback, AeronCError, AeronImage, AeronNotificationCallback,
     AeronSubscription, AeronUnavailableImageCallback, Handler,
 };
-use std::sync::mpsc::Sender;
+use std::sync::{Arc, mpsc::Sender};
 use tracing::{error, info};
 
 pub const DUOLOGUE_STREAM_ID: i32 = 1002;
+/// Upper bound on fragments consumed per poll.
+///
+/// Must not exceed the disruptor ring capacity (`vex_server::engine::BUFFER_SIZE`), otherwise a
+/// single poll can hand the ring more commands than it can hold and the excess is rejected. The
+/// value is duplicated rather than imported because `server` depends on `networking`, not the
+/// reverse; keep the two in step.
+const RING_BUFFER_CAPACITY: usize = 1024;
 
 pub struct Duologue {
     fragment_handler: Option<Handler<FragmentHandler>>,
@@ -27,10 +35,12 @@ impl Duologue {
         on_image_unavailable_handler: Handler<DuologueImageUnavailable>,
         gateway_id: u8,
         producer: MultiProducer<OrderCommand, SingleConsumerBarrier>,
+        publications: Arc<Publications>,
     ) -> Self {
         let fragment_handler = FragmentHandler {
             gateway_id,
             producer,
+            publications,
         };
 
         Self {
@@ -45,7 +55,7 @@ impl Duologue {
 
     pub fn poll(&self) -> Result<i32, AeronCError> {
         if let Some(handler) = &self.fragment_handler {
-            self.subscription.poll(Some(handler), 2048)
+            self.subscription.poll(Some(handler), RING_BUFFER_CAPACITY)
         } else {
             // should not reach here as the handler is only taken during close()
             Ok(0)

--- a/networking/src/server/gateway_manager.rs
+++ b/networking/src/server/gateway_manager.rs
@@ -793,6 +793,7 @@ impl GatewayManager {
                     .expect("image unavailable handler missing"),
                 pending.gateway_id,
                 self.producer.clone(),
+                Arc::clone(&self.publications),
             );
             let attach_result = {
                 self.gateway_sessions.write().unwrap().attach_duologue(

--- a/processors/src/risk_engine.rs
+++ b/processors/src/risk_engine.rs
@@ -1022,8 +1022,8 @@ mod tests {
             engine.get_balance(maker_id, base_asset_id),
             engine.get_balance(maker_id, quote_asset_id),
         ];
-        // MatcherTradeEvent implements Drop (PR #179): assign the fields
-        // instead of functional-update syntax, which moves out of a Drop type.
+        // MatcherTradeEvent implements Drop (iterative chain teardown, PR #179), so the
+        // functional-update form would move out of a Drop type. Assign the fields instead.
         let mut trade_event = MatcherTradeEvent::default();
         trade_event.price = execution_price;
         trade_event.size = size;


### PR DESCRIPTION
## The problem

When the disruptor ring was full, the order was thrown away:

```rust
if let Err(e) = self.producer.try_publish(|cmd| { *cmd = order_command.clone(); }) {
    error!(target: "gateway_fragment", ..., "failed to publish order command to ring buffer");
}
// cmd_handler.rs:24-33 — and that is all that happens
```

The client was never told: no rejection, no NACK. It was not archived either, because journaling is
a pipeline stage a dropped command never reaches. On the gateway side this surfaced as a 5-second
timeout returning HTTP 408 with `order_id 0`, so a dropped order and a dropped response are
indistinguishable to a client — it cannot know whether to retry.

It was also easy to hit: `Duologue::poll` used a fragment limit of **2048** against a **1024**-slot
ring, so a single poll could hand the ring twice its capacity.

## The fix

- On `try_publish` failure, mark the command `Status::Rejected` and send it back to the originating
  gateway via the existing `Publications::publish_response`. `route_gateway_id` is already set
  earlier in the handler, so it routes correctly. The client now gets a definitive answer instead of
  a timeout.
- Lower the poll fragment limit to the ring capacity so one poll cannot overrun it 2×.

The ingress thread still never blocks and never retries — it is the single Aeron poll thread for
every gateway, so stalling it would be worse than the problem being fixed.

## Note on the constant

`RING_BUFFER_CAPACITY` duplicates `vex_server::engine::BUFFER_SIZE` rather than importing it,
because `server` depends on `networking` and not the reverse. It carries a doc comment saying so.
Hoisting the value into `common` would be the cleaner end state but is a wider change than this fix
warrants.

## No unit test

Observing the response requires a concrete `AeronPublication`, so a test without a live Aeron media
driver would assert nothing meaningful. Stated plainly rather than adding a vacuous one.

## Cross-reference

The gateway-side symptom — a 408 with no idempotency key and no reconciliation — is
trade-vex/vex-gateway#54. This change removes the ambiguity for the ring-full case specifically.

## Verification

`cargo check` and `cargo clippy --workspace --all-targets` clean; `cargo test -p vex-networking -p
common` passes.

Closes #123
