### PR TITLE
fix(orderbook): make the cancel index side-aware so a shared price cannot orphan an order

### DIFF
--- a/orderbook/src/lib.rs
+++ b/orderbook/src/lib.rs
@@ -15,8 +15,9 @@
 //!     -   **Order Queue (`VecDeque`):** Within each `PriceLevel`, a `VecDeque` stores the orders.
 //!         This acts as a FIFO (First-In, First-Out) queue, ensuring time priority for orders
 //!         at the same price.
-//!     -   **Direct Order Access (`HashMap`):** A `HashMap<u64, u64>` provides O(1) average-case
-//!         lookup time for order-price pairs by their ID. This is crucial for fast cancellation.
+//!     -   **Direct Order Access (`HashMap`):** A `HashMap<u64, (u64, Side)>` provides O(1)
+//!         average-case lookup time for order price and side by ID. This is crucial for fast
+//!         cancellation.
 //!
 //! 2.  **Performance Characteristics:** [Depends on BookSide Implementation]
 //!     [For BTreeMap-based BookSide]
@@ -68,7 +69,7 @@ impl PriceLevel {
     }
 
     #[inline]
-    fn remove_order(&mut self, order_id: u64, cmd: &mut OrderCommand) {
+    fn remove_order(&mut self, order_id: u64, cmd: &mut OrderCommand) -> bool {
         if let Ok(pos) = self
             .orders
             .binary_search_by_key(&order_id, |order| order.order_id)
@@ -81,8 +82,10 @@ impl PriceLevel {
             cmd.set_side(removed_order.side);
             cmd.set_status(Status::Cancelled);
             cmd.original_size = removed_order.original_size;
+            true
         } else {
             cmd.set_status(Status::Rejected);
+            false
         }
     }
 
@@ -105,7 +108,7 @@ pub struct OrderBook<Ask: BookSide, Bid: BookSide> {
     /// Asks are stored in a BTreeMap sorted from low to high price.
     asks: Ask,
     /// Orders for fast lookups in case of cancellations
-    orders: HashMap<u64, u64>,
+    orders: HashMap<u64, (u64, Side)>,
     /// Market ID for this order book
     market_id: u32,
 }
@@ -322,17 +325,26 @@ impl<Ask: BookSide, Bid: BookSide> OrderBook<Ask, Bid> {
         if cmd.status == Status::Rejected {
             return;
         }
-        if let Some(price) = self.orders.remove(&cmd.order_id) {
-            if let Some(level) = self.bids.get_level_mut(price) {
-                level.remove_order(cmd.order_id, cmd);
-                self.bids.remove_level_if_empty(price);
-                self.record_snapshot(cmd);
-            } else if let Some(level) = self.asks.get_level_mut(price) {
-                level.remove_order(cmd.order_id, cmd);
-                self.asks.remove_level_if_empty(price);
+        if let Some((price, side)) = self.orders.get(&cmd.order_id).copied() {
+            let removed = match side {
+                Side::Bid => self
+                    .bids
+                    .get_level_mut(price)
+                    .is_some_and(|level| level.remove_order(cmd.order_id, cmd)),
+                Side::Ask => self
+                    .asks
+                    .get_level_mut(price)
+                    .is_some_and(|level| level.remove_order(cmd.order_id, cmd)),
+            };
+
+            if removed {
+                self.orders.remove(&cmd.order_id);
+                match side {
+                    Side::Bid => self.bids.remove_level_if_empty(price),
+                    Side::Ask => self.asks.remove_level_if_empty(price),
+                }
                 self.record_snapshot(cmd);
             } else {
-                // this must ideally be unreachable, to avoid any undefined behaviour, we reject the order
                 cmd.set_status(Status::Rejected);
             }
         } else {
@@ -371,7 +383,7 @@ impl<Ask: BookSide, Bid: BookSide> OrderBook<Ask, Bid> {
             Side::Ask => self.asks.get_or_create_level(cmd.price),
         };
         level.add_order(order);
-        self.orders.insert(cmd.order_id, cmd.price);
+        self.orders.insert(cmd.order_id, (cmd.price, cmd.side));
         true
     }
 

--- a/orderbook/src/unit_tests.rs
+++ b/orderbook/src/unit_tests.rs
@@ -40,7 +40,7 @@ mod test {
             expected_volume: u64,
             expected_order_count: usize,
         ) {
-            let (book_side, order_map): (&dyn BookSide, &HashMap<u64, u64>) = match side {
+            let (book_side, order_map): (&dyn BookSide, &HashMap<u64, (u64, Side)>) = match side {
                 Side::Bid => (&self.bids, &self.orders),
                 Side::Ask => (&self.asks, &self.orders),
             };
@@ -84,7 +84,7 @@ mod test {
                 for order in &level.orders {
                     assert_eq!(
                         order_map.get(&order.order_id),
-                        Some(&price),
+                        Some(&(price, side)),
                         "Order map out of sync for order_id {}",
                         order.order_id
                     );
@@ -99,25 +99,16 @@ mod test {
         /// Get the best bid price and volume
         pub fn verify_state(&mut self) -> Result<(), String> {
             // Check that each order referenced in self.orders exists in one of the sides
-            for (order_id, price) in &self.orders {
-                let mut found = false;
-
-                if let Some(level) = self.bids.get_level_mut(*price)
-                    && level.orders.iter().any(|o| o.order_id == *order_id)
-                {
-                    found = true;
+            for (order_id, &(price, side)) in &self.orders {
+                let found = match side {
+                    Side::Bid => self.bids.get_level_mut(price),
+                    Side::Ask => self.asks.get_level_mut(price),
                 }
-
-                if !found
-                    && let Some(level) = self.asks.get_level_mut(*price)
-                    && level.orders.iter().any(|o| o.order_id == *order_id)
-                {
-                    found = true;
-                }
+                .is_some_and(|level| level.orders.iter().any(|o| o.order_id == *order_id));
 
                 if !found {
                     return Err(format!(
-                        "Order {order_id} at price {price} not found on either side"
+                        "Order {order_id} at price {price} not found on {side:?} side"
                     ));
                 }
             }
@@ -187,19 +178,12 @@ mod test {
 
         /// Get order by ID (for testing)
         pub fn get_order(&mut self, order_id: u64) -> Option<&Order> {
-            // Check bids first
-            if let Some(price) = self.orders.get(&order_id) {
-                if *price <= self.bids.best_price()
-                    && let Some(level) = self.bids.get_level_mut(*price)
-                {
-                    return level.orders.iter().find(|o| o.order_id == order_id);
-                } else if let Some(price) = self.orders.get(&order_id)
-                    && let Some(level) = self.asks.get_level_mut(*price)
-                {
-                    return level.orders.iter().find(|o| o.order_id == order_id);
-                }
-            }
-            None
+            let &(price, side) = self.orders.get(&order_id)?;
+            let level = match side {
+                Side::Bid => self.bids.get_level_mut(price),
+                Side::Ask => self.asks.get_level_mut(price),
+            }?;
+            level.orders.iter().find(|o| o.order_id == order_id)
         }
     }
 
@@ -982,6 +966,114 @@ mod test {
         assert_eq!(book.total_order_count(), 0);
         assert_eq!(book.best_bid(), None);
         assert!(book.verify_state().is_ok());
+    }
+
+    #[test]
+    fn test_cancel_orders_on_both_sides_at_same_price() {
+        let (mut book, price_cache) = create_test_orderbook();
+
+        let mut bid = create_order_command(
+            OrderCommandType::PlaceOrder,
+            1,
+            100,
+            1001,
+            1,
+            1000,
+            10,
+            Side::Bid,
+            TimeInForce::Gtc,
+        );
+        book.place_order(&mut bid, price_cache.clone());
+
+        let mut ask = create_order_command(
+            OrderCommandType::PlaceOrder,
+            2,
+            101,
+            1001,
+            1,
+            1000,
+            10,
+            Side::Ask,
+            TimeInForce::Gtc,
+        );
+        book.place_order(&mut ask, price_cache.clone());
+
+        assert_eq!(book.get_level_order_count(Side::Bid, 1000), 1);
+        assert_eq!(book.get_level_order_count(Side::Ask, 1000), 1);
+
+        let mut cancel_ask = create_order_command(
+            OrderCommandType::CancelOrder,
+            ask.order_id,
+            102,
+            ask.user_id,
+            1,
+            0,
+            0,
+            Side::Bid,
+            TimeInForce::Gtc,
+        );
+        book.cancel_order(&mut cancel_ask, price_cache.clone());
+
+        assert_eq!(cancel_ask.status(), Status::Cancelled);
+        assert_eq!(cancel_ask.side, Side::Ask);
+        assert_eq!(book.get_level_order_count(Side::Ask, 1000), 0);
+        assert_eq!(book.get_level_order_count(Side::Bid, 1000), 1);
+
+        let mut cancel_bid = create_order_command(
+            OrderCommandType::CancelOrder,
+            bid.order_id,
+            103,
+            bid.user_id,
+            1,
+            0,
+            0,
+            Side::Ask,
+            TimeInForce::Gtc,
+        );
+        book.cancel_order(&mut cancel_bid, price_cache.clone());
+
+        assert_eq!(cancel_bid.status(), Status::Cancelled);
+        assert_eq!(cancel_bid.side, Side::Bid);
+        assert_eq!(book.total_order_count(), 0);
+        assert!(book.orders.is_empty());
+        assert!(book.verify_state().is_ok());
+    }
+
+    #[test]
+    fn test_cancel_orders_on_single_sided_books() {
+        for (order_id, side) in [(1, Side::Bid), (2, Side::Ask)] {
+            let (mut book, price_cache) = create_test_orderbook();
+            let mut order = create_order_command(
+                OrderCommandType::PlaceOrder,
+                order_id,
+                100,
+                1001,
+                1,
+                1000,
+                10,
+                side,
+                TimeInForce::Gtc,
+            );
+            book.place_order(&mut order, price_cache.clone());
+
+            let mut cancel = create_order_command(
+                OrderCommandType::CancelOrder,
+                order_id,
+                101,
+                order.user_id,
+                1,
+                0,
+                0,
+                side,
+                TimeInForce::Gtc,
+            );
+            book.cancel_order(&mut cancel, price_cache);
+
+            assert_eq!(cancel.status(), Status::Cancelled);
+            assert_eq!(book.get_level_order_count(side, 1000), 0);
+            assert!(book.orders.is_empty());
+            assert!(book.verify_state().is_ok());
+        }
     }
 
     #[test]
@@ -2886,7 +2978,10 @@ mod test {
         assert_eq!(buy_cmd.status(), Status::Placed);
         assert!(buy_cmd.events().is_none());
         book.assert_level_state(Side::Bid, 99_000, 10, 1);
-        assert_eq!(book.orders.get(&buy_cmd.order_id), Some(&99_000));
+        assert_eq!(
+            book.orders.get(&buy_cmd.order_id),
+            Some(&(99_000, Side::Bid))
+        );
 
         let mut sell_cmd =
             harness.create_place_order_cmd(202, Side::Ask, 101_000, 5, TimeInForce::Gtc);
@@ -2895,7 +2990,10 @@ mod test {
         assert_eq!(sell_cmd.status(), Status::Placed);
         assert!(sell_cmd.events().is_none());
         book.assert_level_state(Side::Ask, 101_000, 5, 1);
-        assert_eq!(book.orders.get(&sell_cmd.order_id), Some(&101_000));
+        assert_eq!(
+            book.orders.get(&sell_cmd.order_id),
+            Some(&(101_000, Side::Ask))
+        );
     }
 
     #[test]
@@ -2981,7 +3079,7 @@ mod test {
 
         book.assert_level_state(Side::Ask, 100_000, 0, 0);
         book.assert_level_state(Side::Bid, 100_000, 5, 1);
-        assert_eq!(book.orders.get(&buy_order_id), Some(&100_000));
+        assert_eq!(book.orders.get(&buy_order_id), Some(&(100_000, Side::Bid)));
     }
 
     #[test]
@@ -3006,7 +3104,10 @@ mod test {
 
         book.assert_level_state(Side::Bid, 100_000, 0, 0);
         book.assert_level_state(Side::Ask, 100_000, 8, 1);
-        assert_eq!(book.orders.get(&sell_cmd.order_id), Some(&100_000));
+        assert_eq!(
+            book.orders.get(&sell_cmd.order_id),
+            Some(&(100_000, Side::Ask))
+        );
     }
 
     #[test]


### PR DESCRIPTION
## The problem

`OrderBook::cancel_order` resolved a resting order from `orders: HashMap<u64, u64>`, which maps
`order_id -> price` only. It then removed the index entry **first** and probed `bids`, falling back
to `asks`:

```rust
if let Some(price) = self.orders.remove(&cmd.order_id) {
    if let Some(level) = self.bids.get_level_mut(price) { ... }
    else if let Some(level) = self.asks.get_level_mut(price) { ... }
```

`cmd.side` was ignored — and it is unreliable for a cancel anyway, since the gateway does not know
the resting side.

When both sides hold a level at the same price, an **ask** resolves to the **bid** level, the
binary search inside `remove_order` misses, and the cancel is rejected. Because the index entry was
already removed, the retry is rejected too: the order rests forever and the user's funds stay
locked with no way to release them.

That state is reachable in normal operation. Self-trade prevention makes the matcher `continue`
past a user's own resting order, so the aggressor rests instead of crossing — leaving a level on
each side at the same price.

## The fix

- `orders` becomes `HashMap<u64, (u64, Side)>`. The side is recorded at `add_to_book`, the single
  insertion point, so a cancel goes directly to the correct side instead of probing.
- The index entry is now removed **only after** the level removal succeeds, so a failed cancel is
  retryable rather than self-destructive.
- `PriceLevel::remove_order` returns `bool` so `cancel_order` can tell the two apart.

`Side` is a one-byte enum, so the index value grows from 8 to 16 bytes with alignment — one entry
per resting order. Cancel goes from up to two level probes to exactly one.

## Tests

`orderbook/src/unit_tests.rs` gains coverage for a bid and an ask resting at the same price (each
cancellable by its owner, book empty afterwards) and for ordinary single-sided cancels on both
sides. The `verify_state` invariant checker is now side-aware, so every existing test asserts the
index side matches the level the order actually sits in.

`cargo test -p vex-orderbook`: 75 passed, 0 failed. clippy: 0 warnings.

## Related

Closes #122

- vex-core #80 — earlier report of the same cancel path (suggested a linear scan; this fix keeps
  the O(1) index and makes it side-aware instead).
- vex-core #148 — adds the ownership check inside `PriceLevel::remove_order`; touches the same
  function signature, so whichever merges second will need a trivial rebase.
- vex-gateway #53 — closed as addressed engine-side; the gateway cannot validate a cancel because
  resting orders only reach Postgres via async Kafka.
