### PR TITLE
fix(engine): give journaling its own barrier so the archive record cannot race Risk R1

### DIFF
--- a/server/src/engine.rs
+++ b/server/src/engine.rs
@@ -286,6 +286,9 @@ impl CoreEngine {
         };
         let pipeline = pipeline.handle_events_with(journaling_handler);
 
+        // Dependency barrier: risk engines wait for journaling
+        let pipeline = pipeline.and_then();
+
         // Stage 2: Risk Engine R1 - parallel risk hold/pre-processing
         let pipeline = if enable_pinning {
             pipeline.pin_at_core(core_pinning.risk_engines[0])
@@ -765,6 +768,9 @@ pub mod test {
                 pipeline
             };
             let pipeline = pipeline.handle_events_with(journaling_handler);
+
+            // Dependency barrier: risk engines wait for journaling
+            let pipeline = pipeline.and_then();
 
             // Stage 2: Risk Engine R1
             let pipeline = if enable_pinning {


### PR DESCRIPTION
## The problem

The disruptor pipeline had no `and_then()` between the journaling handler and the four Risk R1
handlers, so all five ran **concurrently on the same barrier**. In the pinned `disruptor` fork,
`add_event_handler` starts a processor against `self.dependent_barrier()`, which only advances on
`and_then()` — adding handlers without one puts them all in the same stage.

Journaling mints `cmd.order_id` and `cmd.timestamp` and then archives the command, while R1
concurrently rewrites `cmd.price` (market buys) and `cmd.status` on the same slot. The archived
record was therefore written at an arbitrary interleaving relative to R1's mutations: replaying the
archive can reconstruct a state that never existed, and which state you get is non-deterministic.

It also contradicted the documented topology — both `ARCHITECTURE.md` and the ASCII diagram at
`server/src/engine.rs:111-125` already show journaling as a stage of its own preceding R1. The code
was what disagreed, so the docs are unchanged.

## The fix

One `and_then()` after the journaling handler, in the production builder and in the test builder
that mirrors it. Journaling now completes for a sequence before any R1 handler touches that slot.

There is no separate replay pipeline — replay drives the production pipeline with
`ReplayControl` enabled, so it inherits the fix.

The cost is one extra barrier hop of latency: journaling's archive `offer()` no longer overlaps
R1. That is the price of a deterministic archive, and it is what the architecture already claimed
to do.

`cargo test -p vex-server -p processors`: 22 passed, 0 failed. clippy: 0 warnings.

## Related

Closes #127

- vex-core #128 — the `&mut OrderCommand` aliasing between concurrent stages. This removes the
  journaling/R1 instance of it; the remaining same-barrier stages are still tracked there.
- vex-core #116 — journal writes are fire-and-forget. Deterministic ordering is a precondition for
  that fix being worth anything.
- vex-core #131, #132 — replay correctness, which depends on the archive being a faithful record.
