### PR TITLE
fix(archive): retry journal writes and abort rather than losing a record

### DIFF
--- a/networking/src/server/gateway_publications.rs
+++ b/networking/src/server/gateway_publications.rs
@@ -1,10 +1,39 @@
 use arc_swap::ArcSwapOption;
 use common::{MAX_GATEWAYS, ORDERCOMMANDSIZE, OrderCommand, encode_order_command};
-use rusteron_archive::{AeronPublication, AeronReservedValueSupplierLogger};
-use std::sync::Arc;
+use rusteron_archive::{
+    AeronPublication, AeronReservedValueSupplierLogger,
+    bindings::{
+        AERON_PUBLICATION_ADMIN_ACTION, AERON_PUBLICATION_BACK_PRESSURED,
+        AERON_PUBLICATION_NOT_CONNECTED,
+    },
+};
+use std::{sync::Arc, time::Duration};
 use tracing::{debug, error};
 
 use super::ServerError;
+
+const ARCHIVE_OFFER_RETRY_LIMIT: usize = 5_000;
+const ARCHIVE_OFFER_RETRY_BACKOFF: Duration = Duration::from_millis(1);
+
+#[derive(Debug, PartialEq, Eq)]
+enum OfferResult {
+    Success,
+    Retryable,
+    Fatal,
+}
+
+fn classify_offer_result(result: i64) -> OfferResult {
+    if result >= 0 {
+        OfferResult::Success
+    } else if result == i64::from(AERON_PUBLICATION_BACK_PRESSURED)
+        || result == i64::from(AERON_PUBLICATION_ADMIN_ACTION)
+        || result == i64::from(AERON_PUBLICATION_NOT_CONNECTED)
+    {
+        OfferResult::Retryable
+    } else {
+        OfferResult::Fatal
+    }
+}
 
 /// Manages Gateway Publications from gateway id 0 to MAX_GATEWAYS - 1
 /// Index MAX_GATEWAYS is reserved for archival publication
@@ -112,8 +141,9 @@ impl Publications {
         let ptr = self.gateways[MAX_GATEWAYS].load_full();
         let publication = ptr.as_ref();
         if publication.is_none() {
-            error!(
-                "gateway-{}: Archive publication not set, cannot archive command, client order_id: {}",
+            // None means archive recording is not configured; see server/mod.rs.
+            debug!(
+                "gateway-{}: Archive recording not configured, skipping command, client order_id: {}",
                 gateway_id, cmd.client_order_id
             );
             return;
@@ -122,26 +152,37 @@ impl Publications {
         let mut response_buffer = [0; ORDERCOMMANDSIZE];
         match encode_order_command(cmd, &mut response_buffer) {
             Ok(_) => {
-                let result =
-                    publication.offer::<AeronReservedValueSupplierLogger>(&response_buffer, None);
+                for retry in 0..=ARCHIVE_OFFER_RETRY_LIMIT {
+                    let result = publication
+                        .offer::<AeronReservedValueSupplierLogger>(&response_buffer, None);
 
-                if result < 0 {
-                    error!(
-                        "gateway-{}: Failed to archive OrderCommand, client order_id: {}, result: {}",
-                        gateway_id, cmd.client_order_id, result
-                    );
-                } else {
-                    debug!(
-                        "gateway-{}: successfully published to archive, client order_id: {}",
-                        gateway_id, cmd.client_order_id
-                    );
+                    match classify_offer_result(result) {
+                        OfferResult::Success => {
+                            debug!(
+                                "gateway-{}: successfully published to archive, client order_id: {}",
+                                gateway_id, cmd.client_order_id
+                            );
+                            return;
+                        }
+                        OfferResult::Retryable if retry < ARCHIVE_OFFER_RETRY_LIMIT => {
+                            std::thread::sleep(ARCHIVE_OFFER_RETRY_BACKOFF);
+                        }
+                        OfferResult::Retryable | OfferResult::Fatal => {
+                            error!(
+                                "gateway-{}: Failed to archive OrderCommand, client order_id: {}, result: {}",
+                                gateway_id, cmd.client_order_id, result
+                            );
+                            std::process::abort();
+                        }
+                    }
                 }
             }
             Err(e) => {
                 error!(
-                    "gateway-{}: Failed to encode processed OrderCommand: {:?}",
-                    gateway_id, e
+                    "gateway-{}: Failed to encode archive OrderCommand, client order_id: {}, error: {:?}",
+                    gateway_id, cmd.client_order_id, e
                 );
+                std::process::abort();
             }
         }
     }
@@ -165,5 +206,43 @@ mod tests {
             publications.get(MAX_GATEWAYS as u8),
             Err(ServerError::GatewayMessageError(_))
         ));
+    }
+
+    use rusteron_archive::bindings::{
+        AERON_PUBLICATION_ADMIN_ACTION, AERON_PUBLICATION_BACK_PRESSURED, AERON_PUBLICATION_CLOSED,
+        AERON_PUBLICATION_ERROR, AERON_PUBLICATION_MAX_POSITION_EXCEEDED,
+        AERON_PUBLICATION_NOT_CONNECTED,
+    };
+
+    #[test]
+    fn classifies_successful_offer() {
+        assert_eq!(classify_offer_result(0), OfferResult::Success);
+        assert_eq!(classify_offer_result(1), OfferResult::Success);
+    }
+
+    #[test]
+    fn classifies_retryable_offer_results() {
+        for result in [
+            AERON_PUBLICATION_BACK_PRESSURED,
+            AERON_PUBLICATION_ADMIN_ACTION,
+            AERON_PUBLICATION_NOT_CONNECTED,
+        ] {
+            assert_eq!(
+                classify_offer_result(i64::from(result)),
+                OfferResult::Retryable
+            );
+        }
+    }
+
+    #[test]
+    fn classifies_fatal_offer_results() {
+        for result in [
+            AERON_PUBLICATION_CLOSED,
+            AERON_PUBLICATION_MAX_POSITION_EXCEEDED,
+            AERON_PUBLICATION_ERROR,
+        ] {
+            assert_eq!(classify_offer_result(i64::from(result)), OfferResult::Fatal);
+        }
+        assert_eq!(classify_offer_result(-7), OfferResult::Fatal);
     }
 }


### PR DESCRIPTION
## The problem

`publish_to_archive` called `offer()` once and, on a negative result, only logged an `error!` and
returned normally. `journal_command` then let the command continue down the pipeline as if the
record had been written.

Negative `offer()` results are routine in Aeron, not exceptional — `BACK_PRESSURED` when the
subscriber falls behind, `ADMIN_ACTION` at term rotation, `NOT_CONNECTED` if the archive subscriber
drops. Every one of them was a silent hole in the journal. Replay then rebuilds a state that never
existed and reports success.

## The fix

`publish_to_archive` classifies the `offer()` result and acts on it:

- **Retryable** (`BACK_PRESSURED`, `ADMIN_ACTION`, `NOT_CONNECTED`) — retry with a 1 ms backoff, up
  to 5,000 times. That is a 5-second budget, which is far beyond any normal term rotation or
  back-pressure spike but still bounded, so a genuinely dead archive cannot wedge the pipeline
  indefinitely.
- **Fatal** (`CLOSED`, `MAX_POSITION_EXCEEDED`, anything unrecognised) — no retry, it cannot succeed.
- **Budget exhausted, fatal result, or an encode failure** — log the client order id and the last
  result code, then `std::process::abort()`. Losing the process is strictly better than accepting an
  order whose journal record does not exist. This follows the precedent set for pipeline handler
  panics in #129.

Classification is a pure function, unit-tested against every result code the `rusteron` bindings
expose, using the named constants rather than raw integers.

**Archiving remains optional.** When no archive channels are configured, `set_archive_publication`
is never called and `server/mod.rs:133` logs `archive_recording = false` as a normal startup. That
slot is never cleared, so `None` unambiguously means "archiving is off" — the write is skipped
quietly and nothing aborts. The abort applies only where a record was actually meant to exist. There
is a comment at the check saying so, since the obvious "improvement" is to abort there too.

The cost is that a slow archive now applies back-pressure to the whole pipeline instead of being
absorbed by dropping records. That is the correct direction for a matching engine: with #123 in
place, a full ring rejects new orders rather than losing them.

`cargo test -p vex-networking -p processors`: 20 passed, 0 failed. clippy: 0 warnings.

## Scope

This is only about not losing writes. The archived record still has no sequence number and replay
still has no gap detection, so a hole introduced by any other means remains undetectable — tracked
in #131 and #132.

## Related

Closes #116

- vex-core #127 — journaling shared a barrier with Risk R1, so the archived content was
  non-deterministic. Durability is only worth having once ordering is fixed.
- vex-core #131, #132 — replay correctness and sequence/gap detection.
- vex-core #126 — the same fire-and-forget pattern on the client response path, fixed separately.
- vex-core #129 — the abort-on-unrecoverable-fault precedent this follows.
