### PR TITLE
fix(networking): retry the client acknowledgement instead of dropping it on back-pressure

### DIFF
--- a/networking/src/server/gateway_publications.rs
+++ b/networking/src/server/gateway_publications.rs
@@ -13,7 +13,8 @@ use tracing::{debug, error};
 use super::ServerError;
 
 const ARCHIVE_OFFER_RETRY_LIMIT: usize = 5_000;
-const ARCHIVE_OFFER_RETRY_BACKOFF: Duration = Duration::from_millis(1);
+const OFFER_RETRY_BACKOFF: Duration = Duration::from_millis(1);
+const RESPONSE_OFFER_RETRY_LIMIT: usize = 10;
 
 #[derive(Debug, PartialEq, Eq)]
 enum OfferResult {
@@ -32,6 +33,14 @@ fn classify_offer_result(result: i64) -> OfferResult {
         OfferResult::Retryable
     } else {
         OfferResult::Fatal
+    }
+}
+
+fn classify_response_offer_result(result: i64) -> OfferResult {
+    if result == i64::from(AERON_PUBLICATION_NOT_CONNECTED) {
+        OfferResult::Fatal
+    } else {
+        classify_offer_result(result)
     }
 }
 
@@ -111,19 +120,33 @@ impl Publications {
         match encode_order_command(cmd, &mut response_buffer) {
             Ok(_) => {
                 // Send the processed command back
-                let result =
-                    publication.offer::<AeronReservedValueSupplierLogger>(&response_buffer, None);
+                for retry in 0..=RESPONSE_OFFER_RETRY_LIMIT {
+                    let result = publication
+                        .offer::<AeronReservedValueSupplierLogger>(&response_buffer, None);
 
-                if result < 0 {
-                    error!(
-                        "gateway-{}: Failed to send processed OrderCommand, result: {}",
-                        gateway_id, result
-                    );
-                } else {
-                    debug!(
-                        "gateway-{}: Successfully sent processed OrderCommand",
-                        gateway_id
-                    );
+                    match classify_response_offer_result(result) {
+                        OfferResult::Success => {
+                            debug!(
+                                "gateway-{}: Successfully sent processed OrderCommand",
+                                gateway_id
+                            );
+                            return;
+                        }
+                        OfferResult::Retryable if retry < RESPONSE_OFFER_RETRY_LIMIT => {
+                            std::thread::sleep(OFFER_RETRY_BACKOFF);
+                        }
+                        OfferResult::Retryable | OfferResult::Fatal => {
+                            error!(
+                                gateway_id,
+                                client_order_id = cmd.client_order_id,
+                                order_id = cmd.order_id,
+                                final_status = ?cmd.status,
+                                last_result_code = result,
+                                "Failed to send processed OrderCommand"
+                            );
+                            return;
+                        }
+                    }
                 }
             }
             Err(e) => {
@@ -165,7 +188,7 @@ impl Publications {
                             return;
                         }
                         OfferResult::Retryable if retry < ARCHIVE_OFFER_RETRY_LIMIT => {
-                            std::thread::sleep(ARCHIVE_OFFER_RETRY_BACKOFF);
+                            std::thread::sleep(OFFER_RETRY_BACKOFF);
                         }
                         OfferResult::Retryable | OfferResult::Fatal => {
                             error!(
@@ -231,6 +254,44 @@ mod tests {
                 classify_offer_result(i64::from(result)),
                 OfferResult::Retryable
             );
+        }
+    }
+
+    #[test]
+    fn classifies_response_and_archive_offer_results() {
+        assert_eq!(
+            classify_response_offer_result(i64::from(AERON_PUBLICATION_NOT_CONNECTED)),
+            OfferResult::Fatal
+        );
+        assert_eq!(
+            classify_offer_result(i64::from(AERON_PUBLICATION_NOT_CONNECTED)),
+            OfferResult::Retryable
+        );
+
+        for result in [
+            AERON_PUBLICATION_BACK_PRESSURED,
+            AERON_PUBLICATION_ADMIN_ACTION,
+        ] {
+            assert_eq!(
+                classify_response_offer_result(i64::from(result)),
+                OfferResult::Retryable
+            );
+            assert_eq!(
+                classify_offer_result(i64::from(result)),
+                OfferResult::Retryable
+            );
+        }
+
+        for result in [
+            AERON_PUBLICATION_CLOSED,
+            AERON_PUBLICATION_MAX_POSITION_EXCEEDED,
+            AERON_PUBLICATION_ERROR,
+        ] {
+            assert_eq!(
+                classify_response_offer_result(i64::from(result)),
+                OfferResult::Fatal
+            );
+            assert_eq!(classify_offer_result(i64::from(result)), OfferResult::Fatal);
         }
     }
 


### PR DESCRIPTION
> Stacked on #159 (`fix/116-journal-durability`), whose `classify_offer_result` this reuses. Merge
> that first.

## The problem

`publish_response` called `offer()` once and, on a negative result, logged
`"Failed to send processed OrderCommand, result: N"` and returned. No retry.

That response is the client's **only** notification of fill, reject or cancel. The gateway waits 5
seconds for it and then returns HTTP 408 with `order_id 0`, so a dropped response is
indistinguishable from a dropped order — the client cannot tell whether it has a position. A
back-pressure spike or a term rotation, both routine, was enough to cause it.

The log line was no help either: it carried the gateway id and a raw result code, but not the
client order id, the order id or the final status, so an operator could not reconcile by hand.

## The fix

Reuse the classifier added in #159 and retry on retryable results, with a budget of **10 × 1 ms**.

That budget is deliberately 500× smaller than the archive's. `publish_response` runs on the event
handler thread — the last pipeline stage, shared by all gateways — so time spent here is time no
other gateway's response is being sent. `BACK_PRESSURED` and `ADMIN_ACTION` clear in microseconds to
low milliseconds, so 10 ms covers them with room to spare.

`NOT_CONNECTED` is treated as **immediately final on the response path**, unlike on the archive
path. On a gateway publication it means the gateway is gone, and Aeron connection establishment
takes far longer than any budget worth spending on the shared thread. `GatewayManager` only clears
the publication when the image-unavailable handler fires on Aeron's liveness timeout, so without
this every response to a just-died gateway would burn the full budget: 100 in-flight orders would
stall the last stage for a second on behalf of a client that is not listening. `classify_offer_result`
is unchanged — the archive still waits for a subscriber that is about to join — and the divergence is
one small wrapper, unit-tested both ways.

On final failure the error log now carries gateway id, client order id, order id, final status and
the last result code: enough to reconcile the order by hand.

This does **not** abort the process. Unlike a lost journal record, a lost response to one gateway
must not take the exchange down.

`cargo test -p vex-networking -p vex-server`: 15 passed, 0 failed. clippy: 0 warnings.

## Scope

This closes the transient-loss half. It deliberately does **not** add a response sequence number —
that would change the 64-byte SBE wire format on both sides of the link — nor a reconciliation
endpoint. End-to-end certainty for the client is the gateway's side of the contract and is tracked
in vex-gateway #54.

## Related

Closes #126

- vex-core #116 / PR #159 — the same fire-and-forget pattern on the archive path; this branch is
  stacked on it and reuses its classifier.
- vex-gateway #54 — the gateway's 5 s timeout returns HTTP 408 with `order_id 0` and has no
  idempotency key, so the client still cannot distinguish "not sent" from "sent, ack lost".
- vex-gateway #58 — if the gateway's Aeron poll thread dies, the response is lost regardless of what
  the engine does.
