### PR TITLE
fix(client): add a non-blocking order send so callers need not sleep 3.1s on back-pressure

### DIFF
--- a/networking/src/client/mod.rs
+++ b/networking/src/client/mod.rs
@@ -5,6 +5,10 @@ use crate::utils::{
 use common::ORDERCOMMANDSIZE;
 use common::{OrderCommand, encode_order_command, order_debug};
 use rand;
+use rusteron_archive::bindings::{
+    AERON_PUBLICATION_ADMIN_ACTION, AERON_PUBLICATION_BACK_PRESSURED,
+    AERON_PUBLICATION_NOT_CONNECTED,
+};
 use rusteron_archive::{
     Aeron, AeronCError, AeronContext, AeronFragmentHandlerCallback, AeronHeader, AeronPublication,
     AeronReservedValueSupplierLogger, AeronSubscription, Handler,
@@ -238,6 +242,10 @@ pub enum GatewayError {
     CoreError(String),
     #[error("Failed to send message: {0}")]
     SendError(String),
+    /// Publication is temporarily unavailable due to Aeron `NOT_CONNECTED`, `BACK_PRESSURED`, or
+    /// `ADMIN_ACTION`.
+    #[error("Aeron publication is temporarily unavailable")]
+    Unavailable,
     #[error("Protocol error: {0}")]
     ProtocolError(String),
     #[error("Configuration error: {0}")]
@@ -285,7 +293,6 @@ impl Publisher {
 
     /// Sends an OrderCommand to the core
     pub fn send_order_command(&self, order_command: &OrderCommand) -> Result<(), GatewayError> {
-        // Send the binary message directly
         order_debug!(
             "gateway_send_attempt",
             order_command,
@@ -293,19 +300,15 @@ impl Publisher {
         );
 
         let mut message_buffer = [0u8; ORDERCOMMANDSIZE];
-
         encode_order_command(order_command, &mut message_buffer).map_err(|e| {
             GatewayError::ProtocolError(format!("Failed to encode OrderCommand: {e:?}"))
         })?;
 
-        // Send using the buffer directly
         for attempt in 0..MESSAGE_RETRY_COUNT {
-            let result = self
-                .publication
-                .offer::<AeronReservedValueSupplierLogger>(&message_buffer, None);
-
-            if result >= 0 {
-                return Ok(());
+            match self.offer_order_command(&message_buffer) {
+                Ok(()) => return Ok(()),
+                Err(error @ GatewayError::ProtocolError(_)) => return Err(error),
+                Err(_) => {}
             }
 
             // Wait before retrying with exponential backoff
@@ -315,6 +318,40 @@ impl Publisher {
 
         Err(GatewayError::SendError(format!(
             "Failed to send OrderCommand after {MESSAGE_RETRY_COUNT} attempts",
+        )))
+    }
+
+    /// Attempts to send an OrderCommand to the core without retrying
+    pub fn try_send_order_command(&self, order_command: &OrderCommand) -> Result<(), GatewayError> {
+        let mut message_buffer = [0u8; ORDERCOMMANDSIZE];
+
+        encode_order_command(order_command, &mut message_buffer).map_err(|e| {
+            GatewayError::ProtocolError(format!("Failed to encode OrderCommand: {e:?}"))
+        })?;
+
+        self.offer_order_command(&message_buffer)
+    }
+
+    fn offer_order_command(&self, message_buffer: &[u8]) -> Result<(), GatewayError> {
+        let result = self
+            .publication
+            .offer::<AeronReservedValueSupplierLogger>(message_buffer, None);
+
+        classify_order_offer_result(result)
+    }
+}
+
+fn classify_order_offer_result(result: i64) -> Result<(), GatewayError> {
+    if result >= 0 {
+        Ok(())
+    } else if result == i64::from(AERON_PUBLICATION_NOT_CONNECTED)
+        || result == i64::from(AERON_PUBLICATION_BACK_PRESSURED)
+        || result == i64::from(AERON_PUBLICATION_ADMIN_ACTION)
+    {
+        Err(GatewayError::Unavailable)
+    } else {
+        Err(GatewayError::SendError(format!(
+            "Failed to send OrderCommand, result: {result}",
         )))
     }
 }
@@ -730,6 +767,45 @@ impl VexGateway {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn order_offer_result_classifies_success() {
+        assert!(classify_order_offer_result(0).is_ok());
+    }
+
+    #[test]
+    fn order_offer_result_classifies_transient_codes_as_unavailable() {
+        for result in [
+            AERON_PUBLICATION_NOT_CONNECTED,
+            AERON_PUBLICATION_BACK_PRESSURED,
+            AERON_PUBLICATION_ADMIN_ACTION,
+        ] {
+            assert!(matches!(
+                classify_order_offer_result(i64::from(result)),
+                Err(GatewayError::Unavailable)
+            ));
+        }
+    }
+
+    #[test]
+    fn order_offer_result_classifies_closed_publication_as_failure() {
+        assert!(matches!(
+            classify_order_offer_result(i64::from(
+                rusteron_archive::AeronErrorType::PublicationClosed.code()
+            )),
+            Err(GatewayError::SendError(message))
+                if message == "Failed to send OrderCommand, result: -4"
+        ));
+    }
+
+    #[test]
+    fn order_offer_result_classifies_unrecognised_negative_code_as_failure() {
+        assert!(matches!(
+            classify_order_offer_result(-99),
+            Err(GatewayError::SendError(message))
+                if message == "Failed to send OrderCommand, result: -99"
+        ));
+    }
 
     #[test]
     fn test_parse_core_response_accept() {


### PR DESCRIPTION
## The problem

`Publisher::send_order_command` was the **only** way to publish an `OrderCommand`, and it retries an
Aeron `offer` five times with `std::thread::sleep` at 100/200/400/800/1600 ms — 3.1 seconds of
blocking sleep. A caller that cannot afford to block had no alternative and no way to ask whether a
publish would succeed right now.

`vex-gateway` calls this from an actix async handler while holding a process-global `tokio::Mutex`,
so a single back-pressured order blocks an entire worker thread for 3.1 s *and* serialises every
other order behind the mutex. Back-pressure is exactly what happens under load.

## The fix

Additive. `send_order_command` keeps its exact signature, retry count and backoff timing — the
gateway pins this crate by git rev and other callers depend on it.

- **`try_send_order_command`** encodes once, offers once, returns immediately. No loop, no sleep.
- **`GatewayError::Unavailable`** is the transient case, covering Aeron's `NOT_CONNECTED`,
  `BACK_PRESSURED` and `ADMIN_ACTION`. All three mean "the engine cannot take this right now, try
  again", which is one decision for the caller — answer 503 — so it is one variant, documented with
  the codes it covers. A closed publication or an unrecognised code stays a `SendError`.
- Both public functions share one private `offer_order_command` helper, so the retry path and the
  single-shot path cannot drift apart. `send_order_command` still encodes **once** before the loop
  and offers the same bytes each attempt.

`ADMIN_ACTION` being transient matters: it is a routine term rotation. Classifying it as a hard
failure would have the gateway report HTTP 500 for an event that resolves by itself in microseconds.
This matches how `networking/src/server/gateway_publications.rs` already classifies offer results on
the archive and response paths — the client and the server now agree on what "transient" means, using
the same named `rusteron` constants rather than raw integers.

`cargo test -p vex-networking`: 7 passed, 0 failed. clippy: 0 warnings.

## Scope

This is the engine half only. Nothing in `vex-core` calls the new function yet — it exists so the
gateway can stop blocking. The caller-side change is vex-gateway#52 and needs the vex-core pin in
`vex-gateway/Cargo.toml` (currently `rev = "efeaeb4"`) moved to a commit containing this, so this
must merge first.

## Related

Closes #161

- vex-gateway #52 — the caller-side half: publish without blocking a worker, and return 503 instead
  of sleeping.
- vex-core #116 / PR #159 and #126 / PR #160 — the same offer-result classification applied to the
  archive and client-response paths.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a non-blocking option for sending order commands.
  * Improved handling of temporarily unavailable publication channels with automatic retries.

* **Bug Fixes**
  * Protocol errors now return immediately with clearer error reporting.
  * Added handling for closed publications and unexpected publication results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->