### PR TITLE
fix(risk): round fees up so slicing an order is no longer free

### DIFF
--- a/processors/src/risk_engine.rs
+++ b/processors/src/risk_engine.rs
@@ -242,8 +242,8 @@ impl RiskEngine {
             Side::Bid => {
                 let quote_spent = spec.calculate_quote_cost(event.price, event.size);
                 // Fee is on the base asset received. Assuming fee is in basis points (e.g., 20bp = 0.2%)
-                let fee_in_base =
-                    u64::try_from((event.size as u128 * fee as u128) / 10000).unwrap_or(u64::MAX);
+                let fee_in_base = u64::try_from((event.size as u128 * fee as u128).div_ceil(10000))
+                    .unwrap_or(u64::MAX);
                 let base_received_net = event.size.saturating_sub(fee_in_base);
                 (
                     quote_asset(market_id),
@@ -259,7 +259,7 @@ impl RiskEngine {
                 let quote_received_gross = spec.calculate_quote_cost(event.price, event.size);
                 // Fee is on the quote asset received. Assuming fee is in basis points.
                 let fee_in_quote =
-                    u64::try_from((quote_received_gross as u128 * fee as u128) / 10000)
+                    u64::try_from((quote_received_gross as u128 * fee as u128).div_ceil(10000))
                         .unwrap_or(u64::MAX);
                 let quote_received_net = quote_received_gross.saturating_sub(fee_in_quote);
                 (
@@ -556,6 +556,67 @@ mod tests {
             .slippage(5)
             .build()
             .unwrap()
+    }
+
+    fn settled_bid_fees(
+        maker_fee: u64,
+        taker_fee: u64,
+        is_maker: bool,
+        fill_sizes: &[u64],
+    ) -> Vec<u64> {
+        let base_asset_id = 2u16;
+        let quote_asset_id = 1u16;
+        let market_id = ((quote_asset_id as u32) << 16) | base_asset_id as u32;
+        let user_id = 102;
+        let locked_quote = fill_sizes.iter().sum();
+
+        let spec = CoreMarketSpecification::builder()
+            .market_id(market_id)
+            .market_type(MarketType::Spot)
+            .maker_fee(maker_fee)
+            .taker_fee(taker_fee)
+            .slippage(5)
+            .build()
+            .unwrap();
+        let mut specs = HashMap::new();
+        specs.insert(market_id, spec);
+        let engine = RiskEngine::new(specs, 0, 1);
+        engine.set_balance(user_id, quote_asset_id, UserBalance::new(0, locked_quote));
+
+        let mut previous_base_balance = 0;
+        let fees = fill_sizes
+            .iter()
+            .map(|&size| {
+                let mut trade_event = MatcherTradeEvent {
+                    price: 1,
+                    size,
+                    maker_user_id: if is_maker { user_id } else { user_id - 1 },
+                    active_order_completed: false,
+                    matched_order_id: 1,
+                    matched_order_completed: true,
+                    next_event: None,
+                    maker_balance: [UserBalance::default(); 2],
+                    maker_remaining_size: 0,
+                    maker_original_size: size,
+                };
+
+                engine.handle_trade_event(
+                    user_id,
+                    market_id,
+                    Side::Bid,
+                    &mut trade_event,
+                    (!is_maker).then_some(1),
+                );
+
+                let base_balance = engine.get_balance(user_id, base_asset_id).total();
+                let fee = size - (base_balance - previous_base_balance);
+                previous_base_balance = base_balance;
+                fee
+            })
+            .collect();
+
+        assert_eq!(engine.get_balance(user_id, quote_asset_id).total(), 0);
+        fees
     }
 
     #[test]
@@ -1096,6 +1157,29 @@ mod tests {
             size - expected_fee
         );
         assert_eq!(engine.get_balance(user_id, quote_asset_id).total(), 0);
+    }
+
+    #[test]
+    fn test_sliced_fills_each_pay_a_fee() {
+        let fees = settled_bid_fees(0, 20, false, &[499; 20]);
+
+        assert_eq!(fees, vec![1; 20]);
+        assert_eq!(fees.iter().sum::<u64>(), 20);
+    }
+
+    #[test]
+    fn test_zero_maker_fee_stays_zero() {
+        assert_eq!(settled_bid_fees(0, 20, true, &[499]), vec![0]);
+    }
+
+    #[test]
+    fn test_exact_multiple_fee_is_unchanged() {
+        assert_eq!(settled_bid_fees(0, 20, false, &[1_000]), vec![2]);
+    }
+
+    #[test]
+    fn test_one_unit_fill_pays_one_unit_fee() {
+        assert_eq!(settled_bid_fees(0, 20, false, &[1]), vec![1]);
     }
 
     #[test]

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -1360,15 +1360,19 @@ mod tests {
         // gets equivalent base - taker fee
         assert_eq!(taker_d_cmd.balance[0].locked, 0);
         let gross_base_recv = 30;
+        let taker_fee = [10u64, 15, 5]
+            .map(|fill_size| (fill_size * 20).div_ceil(10000))
+            .into_iter()
+            .sum::<u64>();
         assert_eq!(
             taker_d_cmd.balance[0].available,
-            gross_base_recv - (gross_base_recv * 20 / 10000)
+            gross_base_recv - taker_fee
         ); // base after 20bp fee
 
         // Verify balances after Taker D's trade
         // Maker A (fully filled)
-        let maker_a_quote_recv = 10 * 1010;
-        let maker_a_fee = (maker_a_quote_recv * 10) / 10000; // 10bp on quote
+        let maker_a_quote_recv = 10u64 * 1010;
+        let maker_a_fee = (maker_a_quote_recv * 10).div_ceil(10000); // 10bp on quote
         assert_eq!(
             risk_engines[maker_a_shard].get_balance(maker_a_id, base_asset_id),
             UserBalance::new(90, 0)
@@ -1379,8 +1383,8 @@ mod tests {
         );
 
         // Maker B (fully filled)
-        let maker_b_quote_recv = 15 * 1020;
-        let maker_b_fee = (maker_b_quote_recv * 10) / 10000; // 10bp on quote
+        let maker_b_quote_recv = 15u64 * 1020;
+        let maker_b_fee = (maker_b_quote_recv * 10).div_ceil(10000); // 10bp on quote
         assert_eq!(
             risk_engines[maker_b_shard].get_balance(maker_b_id, base_asset_id),
             UserBalance::new(85, 0)
@@ -1391,9 +1395,9 @@ mod tests {
         );
 
         // Maker C (partially filled, 5 remaining)
-        let maker_c_base_sold = 5; // Out of 20, 5 sold
+        let maker_c_base_sold = 5u64; // Out of 20, 5 sold
         let maker_c_quote_recv = maker_c_base_sold * 1020;
-        let maker_c_fee = (maker_c_quote_recv * 10) / 10000; // 10bp on quote
+        let maker_c_fee = (maker_c_quote_recv * 10).div_ceil(10000); // 10bp on quote
         assert_eq!(
             risk_engines[maker_c_shard].get_balance(maker_c_id, quote_asset_id),
             UserBalance::new(maker_c_quote_recv - maker_c_fee, 0)
@@ -1449,18 +1453,17 @@ mod tests {
             UserBalance::new(0, 0)
         );
 
-        // Taker D (buyer, was both taker and maker)
+        // Taker D (taker buyer)
         let taker_d_final_base = risk_engines[taker_d_shard].get_balance(taker_d_id, base_asset_id);
         let taker_d_final_quote =
             risk_engines[taker_d_shard].get_balance(taker_d_id, quote_asset_id);
 
         // Taker D received:
-        // As taker: 10 (from A) + 15 (from B). Fee is 20bp on base. Fee = (25*20)/10000 = 0. Net = 25.
-        // As maker: 5 (from E). Fee is 10bp on base. Fee = (5*10)/10000 = 0. Net = 5.
-        // Total base received: 25 + 5 = 30.
+        // As taker: 10 (from A) + 15 (from B) + 5 (from C). Fee is 20bp on base,
+        // rounded up per fill. Each fill pays 1 BASE in fees, so the net is 27.
         assert_eq!(
             taker_d_final_base.total(),
-            30,
+            27,
             "Taker D final base balance is wrong"
         );
 

--- a/xtask/src/scenarios/ioc.rs
+++ b/xtask/src/scenarios/ioc.rs
@@ -645,6 +645,7 @@ async fn test_market_buy_section(ctx: &mut TestContext) -> TestResult<()> {
     let best_ask_price = 53_000;
     let second_ask_price = 54_000;
     let buy_size = 4;
+    let market_spec = ctx.market_spec().clone();
 
     // Clear the leftover 3 BTC @ 52k from Section 5 to get clean orderbook
     let clear_order = OrderBuilder::place_limit()
@@ -770,13 +771,14 @@ async fn test_market_buy_section(ctx: &mut TestContext) -> TestResult<()> {
         let mut balance_verifier = BalanceVerifier::new(&mut ctx.redis);
 
         // Calculate expected costs
-        let actual_cost = best_ask_price * buy_size; // Executed at best ask
-        let conservative_cost = expected_conservative_price * buy_size; // Locked amount
+        let actual_cost = market_spec.calculate_quote_cost(best_ask_price, buy_size);
+        let conservative_cost =
+            market_spec.calculate_quote_cost(expected_conservative_price, buy_size);
         let expected_refund = conservative_cost - actual_cost; // Price improvement refund
 
-        // Taker fee (10 bps = 0.1%)
-        let taker_fee_bps = 10;
-        let taker_fee_btc = (buy_size * taker_fee_bps) / 10_000;
+        // Bid taker fee is charged on the received base asset.
+        let taker_fee_bps = market_spec.taker_fee;
+        let taker_fee_btc = (buy_size * taker_fee_bps).div_ceil(10_000);
 
         let final_usd_balance = balance_verifier
             .get_balance(users::ALICE, assets::USD)
@@ -862,6 +864,7 @@ async fn test_market_sell_section(ctx: &mut TestContext) -> TestResult<()> {
     let best_bid_price = 52_000;
     let second_bid_price = 51_000;
     let sell_size = 10;
+    let market_spec = ctx.market_spec().clone();
 
     // Setup: Create orderbook with bids
     // Alice places bid @ 52,000 (best bid)
@@ -963,13 +966,10 @@ async fn test_market_sell_section(ctx: &mut TestContext) -> TestResult<()> {
         let mut balance_verifier = BalanceVerifier::new(&mut ctx.redis);
 
         // Calculate expected revenue
-        let gross_revenue = best_bid_price * sell_size;
-
-        // Taker fee (10 bps = 0.1%) is taken from BTC, not USD
-        // For sell_size = 10: fee_btc = (10 * 10) / 10000 = 0 (rounds down)
-        // in real scenario all amt, balances must be scaled, to avoid this.
-        let taker_fee_bps = 10;
-        let taker_fee_btc = (sell_size * taker_fee_bps) / 10_000;
+        let gross_revenue = market_spec.calculate_quote_cost(best_bid_price, sell_size);
+        let taker_fee_bps = market_spec.taker_fee;
+        let taker_fee_usd = (gross_revenue * taker_fee_bps).div_ceil(10_000);
+        let expected_usd = gross_revenue.saturating_sub(taker_fee_usd);
 
         let final_usd_balance = balance_verifier
             .get_balance(users::CHARLIE, assets::USD)
@@ -978,32 +978,35 @@ async fn test_market_sell_section(ctx: &mut TestContext) -> TestResult<()> {
             .get_balance(users::CHARLIE, assets::BTC)
             .await?;
 
-        // Verify BTC sold (including fee if non-zero)
+        // Ask taker fee is charged on the received quote asset, not the base asset.
         let btc_sold = initial_btc_balance.available - final_btc_balance.available;
-        let expected_btc_total = sell_size + taker_fee_btc;
-        if btc_sold != expected_btc_total {
+        if btc_sold != sell_size {
             return Err(TestError::Verification {
                 message: format!(
-                    "BTC sold mismatch: expected={} (size={} + fee={}), actual={}",
-                    expected_btc_total, sell_size, taker_fee_btc, btc_sold
+                    "BTC sold mismatch: expected={} (no base-side fee), actual={}",
+                    sell_size, btc_sold
                 ),
             });
         }
 
-        // Verify USD received (full gross - fee is NOT deducted from USD)
+        // Verify USD received (gross quote revenue minus quote-side taker fee)
         let usd_received = final_usd_balance.available - initial_usd_balance.available;
-        if usd_received != gross_revenue {
+        if usd_received != expected_usd {
             return Err(TestError::Verification {
                 message: format!(
-                    "USD received mismatch: expected={} (full gross), actual={}. Fee is in BTC, not USD.",
-                    gross_revenue, usd_received
+                    "USD received mismatch: expected={} (gross={} - fee={}), actual={}",
+                    expected_usd, gross_revenue, taker_fee_usd, usd_received
                 ),
             });
         }
 
         info!(
-            "  → Charlie final: {} USD (received full gross), {} BTC (sold {} + fee {})",
-            final_usd_balance.available, final_btc_balance.available, sell_size, taker_fee_btc
+            "  → Charlie final: {} USD (received {}, fee {}), {} BTC (sold {})",
+            final_usd_balance.available,
+            expected_usd,
+            taker_fee_usd,
+            final_btc_balance.available,
+            sell_size
         );
     }
 

--- a/xtask/src/test_framework/mod.rs
+++ b/xtask/src/test_framework/mod.rs
@@ -10,7 +10,7 @@ pub mod types;
 use self::client::TestClient;
 use self::redis::RedisVerifier;
 use self::types::*;
-use common::OrderCommand;
+use common::{CoreMarketSpecification, OrderCommand};
 use hashbrown::HashMap;
 use std::time::Duration;
 use tracing::{debug, info};
@@ -52,6 +52,8 @@ pub struct TestContext {
     pub base_asset_id: u16,
     /// Quote asset ID
     pub quote_asset_id: u16,
+    /// Market specification used by the development test server
+    market_spec: CoreMarketSpecification,
     /// User state tracker
     users: HashMap<u64, UserState>,
     /// Test configuration
@@ -80,6 +82,17 @@ impl TestContext {
             config.core_control_port,
         )?;
         let redis = RedisVerifier::new(&config.redis_host, config.redis_port).await?;
+        let market_spec = vex_config::VexConfig::new(vex_config::Environment::Development)
+            .symbols
+            .symbols
+            .get(&config.market_id)
+            .cloned()
+            .ok_or_else(|| TestError::Configuration {
+                message: format!(
+                    "No development market specification for {}",
+                    config.market_id
+                ),
+            })?;
 
         Ok(Self {
             client,
@@ -87,6 +100,7 @@ impl TestContext {
             market_id: config.market_id,
             base_asset_id: config.base_asset_id,
             quote_asset_id: config.quote_asset_id,
+            market_spec,
             users: HashMap::new(),
             config,
         })
@@ -172,6 +186,11 @@ impl TestContext {
     /// Get configuration
     pub fn config(&self) -> &TestConfig {
         &self.config
+    }
+
+    /// Get the market specification used by the test server
+    pub fn market_spec(&self) -> &CoreMarketSpecification {
+        &self.market_spec
     }
 
     /// Cleanup test data


### PR DESCRIPTION
> Stacked on #154 (`fix/119-fee-arithmetic`), whose overflow-safe form this builds on. Merge that
> first.

## The problem

Fees are computed as `(size * fee) / 10000` in basis points. Integer division **floors**, so any
fill below `10000/fee` units pays exactly zero. At a 20bp taker fee that is any fill under 500 units.

Nothing stops a client from slicing:

```
20 slices x 499 units, taker fee 20bp   -> total fee paid = 0
one 9,980-unit order                    -> floor(9980*20/10000) = 19
```

Trading fee-free is a matter of choosing your fill size.

## The fix

Round the fee **up** — `div_ceil(10000)` on both the base-side and quote-side computations.

Boundaries, all covered by new tests:

| Case | Before | After |
|---|---|---|
| rate 0 (maker fee is legitimately 0 in the shipped config) | 0 | 0 |
| exact multiple, e.g. 20,000 units @ 20bp | 40 | 40 |
| 20 × 499 units @ 20bp | 0 total | 1 each, 20 total |
| 1 unit @ 20bp | 0 | 1 |

A zero-fee market stays free — `div_ceil` of zero is zero — so this cannot accidentally start
charging where no fee was configured.

`div_ceil` rather than a hand-rolled `(a + b - 1) / b`, which can overflow. The multiply stays
widened to `u128` and the subtraction stays saturating, exactly as #154 left them.

## Correction: existing test expectations *did* change

This description originally claimed **"No existing test expectation changed."** That was wrong.

The audit behind that claim only covered `processors/src/risk_engine.rs`, where every hard-coded fee
happens to be an exact multiple of 10000 — taker 20,000 @ 20bp = 40, maker 1,000,000,000 @ 10bp =
1,000,000, the 18-decimal fill = 2,000,000,000,000,000, the 1,000-unit fill @ 20bp = 2 — so ceiling
and floor agree there. It never looked at the callers in other crates, and one of them was red:

```
thread 'tests::test_complex_scenario_with_cancellations_and_mixed_tif'
panicked at server/src/lib.rs:1266:9:
assertion `left == right` failed
  left: 27
 right: 30
```

`5a6b931` recomputes those expectations **per fill**, which is the semantics of the fix rather than a
concession to it — the engine applies the rate to each fill, not to the order total, and that is
precisely why slicing no longer helps.

**`vex-server`** — `test_complex_scenario_with_cancellations_and_mixed_tif`. Taker D's 30-unit bid is
filled by three makers: 10 from A, 15 from B, 5 from C. The test encoded the aggregate floor form,
`gross_base_recv - (gross_base_recv * 20 / 10000)` = 30 − 0 = 30. Each of the three fills now rounds
up to 1 BASE, so D nets 27. The maker side moved the same way — A's 10bp on 10,100 quote goes 10 →
11, B's on 15,300 goes 15 → 16, C's on 5,100 goes 5 → 6 — and those asserts now derive the fee with
`div_ceil` instead of restating a floor result.

That test also carried a comment claiming D took 25 units as taker and 5 "as maker (from E)". That
was already false: Taker E's IOC ask is cancelled against an empty book after C cancels, so all 30
units reach D as taker. Under floor rounding every fee was 0, so the wrong narrative still produced
the right number and nothing caught it. Corrected alongside.

**`xtask`** — two IOC scenarios did not merely miss the defect, they asserted it:

- `test_market_buy_section`, 4 units @ 10bp — expected fee 0, now 1.
- `test_market_sell_section`, 10 units @ 10bp — expected fee 0, now 1. Its comment read
  `fee_btc = (10 * 10) / 10000 = 0 (rounds down)`.

So the original description reached the right conclusion from the wrong evidence: the suite was not
blind to this defect everywhere — in places it was pinning the defect in place.

## Verification

`cargo test -p processors`: 19 passed, 0 failed. clippy: 0 warnings.

CI **Build and Test** failed on `00ad7df` and passes on `5a6b931` — `processors` 19 passed / 0
failed, `vex-server` lib 7 passed / 0 failed.

Clippy, End-to-end tests and Security audit are red on this branch and equally red on `develop` at
the merge base (`2852560`): Clippy on a `format!` lint in `vex-networking`, E2E on a `vex-networking`
build failure against `rusteron-archive` (`AeronArchiveContext::new_with_no_credentials_supplier` no
longer exists). Nothing here touches either. The consequence for review is that the two xtask
scenario corrections are right in source but were not exercised by CI on this branch.

## Scope

This makes the fee non-zero. It does **not** change where the fee goes — it is still debited from
the user and credited to no account, which is #118.

## Related

Closes #120

- vex-core #119 / PR #154 — overflow-safe fee arithmetic and the `taker_fee < 10000` bound this
  relies on; stacked on it.
- vex-core #118 — fees are debited and credited nowhere. Rounding up increases the amount that
  currently vanishes.
- vex-core #111 / PR #146 — the related rounding-to-zero defect on the collateral side.
