### PR TITLE
fix(config): never guess the environment or silently fall back to zero-fee defaults

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,7 @@
 *.jar
 **/aeron-archive
 
-*.json
-*.yaml
+# Generated configuration example and cargo-chef outputs
+**/output.json
+**/output.yaml
+**/recipe.json

--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -46,21 +46,21 @@ cargo build --release --features balance-preload
 # Start Aeron Media Driver first (required - vex-core connects to it)
 make media-driver
 
-# Development mode (uses config.dev.yaml or Test defaults)
-RUST_LOG=info cargo run --bin vex-core
+# Development mode (uses config.dev.yaml or Development defaults)
+VEX_ENV=development RUST_LOG=info cargo run --bin vex-core
 
 # Or using Makefile (starts media driver + vex-core)
-make server
+VEX_ENV=development make server
 
 # With journal replay (recover from recorded state)
-./target/release/vex-core --replay
+VEX_ENV=development ./target/release/vex-core --replay
 ```
 
 ### Environment Variables
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `VEX_ENV` / `ENVIRONMENT` / `ENV` | Environment: `development`, `test`, `production` | `development` |
+| `VEX_ENV` / `ENVIRONMENT` / `ENV` / `NODE_ENV` | Environment: `development`, `test`, `production` | Required |
 | `KAFKA_BROKER` | Kafka broker address | `localhost:9092` |
 | `ENABLE_CORE_PINNING` | Enable CPU core pinning for processor threads | `false` (dev/test), `true` (prod) |
 | `RUST_LOG` | Log level (trace, debug, info, warn, error) | `info` |
@@ -81,6 +81,8 @@ make server
 ### Configuration Files
 
 Configuration is loaded from YAML, TOML, or JSON files. Search order (first found wins):
+
+The environment must be selected explicitly with `VEX_ENV`, `ENVIRONMENT`, `ENV`, or `NODE_ENV`. Development and test selections use environment defaults if no matching file is present; production does not.
 
 - `./config.dev.yaml`, `./config.test.yaml`, `./config.prod.yaml`
 - `./config/config.dev.yaml`, etc.
@@ -127,7 +129,7 @@ balance_preload:
 
 ### Configuration Precedence
 
-1. Environment-specific config file (based on `VEX_ENV` / `ENVIRONMENT`)
+1. Environment-specific config file (based on `VEX_ENV` / `ENVIRONMENT` / `ENV` / `NODE_ENV`)
 2. Environment variables with `VEX__` prefix (nested keys use `__`, e.g., `VEX__CORE_NETWORKING__INITIAL_PORT`)
 3. Hardcoded overrides in `main.rs` (e.g., `context_dir`, `local_address`)
 
@@ -152,10 +154,10 @@ Ensure the **Aeron Media Driver uses the same `context_dir`** as vex-core (or th
 make media-driver
 
 # 2. Start vex-core
-RUST_LOG=info ./target/release/vex-core
+VEX_ENV=development RUST_LOG=info ./target/release/vex-core
 
 # Or use Makefile (handles both)
-make server
+VEX_ENV=development make server
 ```
 
 ### Stop Service
@@ -183,14 +185,14 @@ make stop-media-driver
 kill -TERM <pid>
 # Wait for shutdown, then:
 make media-driver  # If needed
-./target/release/vex-core
+VEX_ENV=development ./target/release/vex-core
 ```
 
 ### Journal Replay
 
 ```bash
 # Start with replay from recorded journal
-./target/release/vex-core --replay
+VEX_ENV=development ./target/release/vex-core --replay
 ```
 
 ### View Logs
@@ -198,7 +200,7 @@ make media-driver  # If needed
 ```bash
 # Logs go to stdout by default (development)
 # Redirect if needed:
-./target/release/vex-core 2>&1 | tee logs/vex-core.log
+VEX_ENV=development ./target/release/vex-core 2>&1 | tee logs/vex-core.log
 
 # Production config may write to /var/log/vex/vex-core.log
 tail -f /var/log/vex/vex-core.log
@@ -215,7 +217,7 @@ tail -f /var/log/vex/vex-core.log
 **Diagnosis**:
 ```bash
 # Check configuration loading
-RUST_LOG=debug ./target/release/vex-core 2>&1 | head -50
+VEX_ENV=development RUST_LOG=debug ./target/release/vex-core 2>&1 | head -50
 
 # Verify config file exists for your environment
 ls -la config.dev.yaml config.test.yaml config.prod.yaml 2>/dev/null
@@ -224,7 +226,8 @@ ls -la config.dev.yaml config.test.yaml config.prod.yaml 2>/dev/null
 ```
 
 **Solutions**:
-- Ensure a config file exists for the detected environment, or that defaults are acceptable
+- Set `VEX_ENV`, `ENVIRONMENT`, `ENV`, or `NODE_ENV` to the intended environment
+- Ensure a config file exists for the selected environment, or that development/test defaults are acceptable
 - Verify `KAFKA_BROKER` is reachable if Kafka is required
 - Check that `/dev/shm` has sufficient space for Aeron
 - Verify symbol configuration is valid (market_id, assets, fees)
@@ -305,7 +308,7 @@ netstat -tuln | grep -E "40001|3521"
 top -p $(pgrep vex-core)
 
 # Review disruptor/processor logs
-RUST_LOG=debug ./target/release/vex-core 2>&1 | grep -E "disruptor|processor|backpressure"
+VEX_ENV=development RUST_LOG=debug ./target/release/vex-core 2>&1 | grep -E "disruptor|processor|backpressure"
 ```
 
 **Solutions**:
@@ -375,7 +378,7 @@ top -p $(pgrep vex-core)
 4. **Restart**
    ```bash
    make media-driver    # If needed
-   ./target/release/vex-core
+   VEX_ENV=development ./target/release/vex-core
    ```
 
 ### Media Driver is Down
@@ -392,7 +395,7 @@ top -p $(pgrep vex-core)
 
 3. **Restart vex-core**
    ```bash
-   ./target/release/vex-core
+   VEX_ENV=development ./target/release/vex-core
    ```
 
 ### Kafka is Down
@@ -428,7 +431,7 @@ top -p $(pgrep vex-core)
 
 ```bash
 # Start with replay to recover state from last recording
-./target/release/vex-core --replay
+VEX_ENV=development ./target/release/vex-core --replay
 ```
 
 ---
@@ -476,4 +479,3 @@ VEX Core is a **low-latency matching engine** with no HTTP API. It communicates 
 | `networking/src/server/` | Aeron server, gateway handshake, publications |
 | `vex-config/` | Configuration loading and validation |
 | `config.dev.yaml` | Example development config |
-

--- a/config.dev.yaml
+++ b/config.dev.yaml
@@ -1,0 +1,77 @@
+environment: development
+core_networking:
+  context_dir: /dev/shm/aeron-test-server
+  local_address: 127.0.0.1
+  initial_port: 40001
+  initial_control_port: 40002
+  base_gateway_port: 50000
+  max_gateways: 15
+  reserved_session_id_low: 1000
+  reserved_session_id_high: 9999
+  enable_authentication: false
+  core_id: vex-core-dev
+  buffer_size: 1048576
+  retry_attempts: 3
+  retry_delay_ms: 1000
+  request_control_channel: aeron:udp?endpoint=localhost:8010
+  response_control_channel: aeron:udp?endpoint=localhost:0
+  recording_events_channel: aeron:udp?endpoint=localhost:0
+  enable_core_pinning: false
+gateway_networking:
+  context_dir: /tmp/aeron-test-client
+  local_address: 127.0.0.1
+  core_address: 127.0.0.1
+  core_port: 3521
+  core_control_port: 3522
+  gateway_id: 1
+  max_message_size: 64
+  enable_heartbeat: true
+  heartbeat_interval_seconds: 10
+  connection_timeout_seconds: 60
+  reconnection_attempts: 5
+  reconnection_delay_ms: 2000
+  buffer_size: 524288
+logging:
+  level: debug
+  format: pretty
+  outputs:
+    - type: stdout
+  module_levels:
+    vex_core: debug
+    networking: debug
+    orderbook: info
+  include_location: true
+  include_timestamp: true
+  include_thread_id: true
+  include_spans: true
+  custom_fields: {}
+  async_logging: false
+  async_buffer_size: 1024
+  sampling_rate: 1.0
+symbols:
+  symbols:
+    "65539":
+      market_id: 65539
+      market_type: Spot
+      base_asset: 3
+      quote_asset: 1
+      base_scale_k: 100000
+      quote_scale_k: 10
+      base_native_scale: 1000000000000000000
+      quote_native_scale: 1000000
+      taker_fee: 0
+      maker_fee: 0
+      slippage: 150
+    "65538":
+      market_id: 65538
+      market_type: FuturesContract
+      base_asset: 2
+      quote_asset: 1
+      base_scale_k: 1
+      quote_scale_k: 1
+      base_native_scale: 100000000
+      quote_native_scale: 1000000
+      taker_fee: 0
+      maker_fee: 0
+      slippage: 150
+kafka_broker: localhost:9092

--- a/docker/DOCKER_README.md
+++ b/docker/DOCKER_README.md
@@ -43,7 +43,7 @@ This will:
 To run the complete application (media driver + vex-core):
 
 ```bash
-./docker-scripts.sh start-full
+VEX_ENV=development ./docker-scripts.sh start-full
 ```
 
 ## Docker Files
@@ -103,7 +103,7 @@ docker-compose up --build sbe-generator
 
 ### Start Full Application
 ```bash
-docker-compose up --build
+VEX_ENV=development docker-compose up --build
 ```
 
 ## SBE Code Generation
@@ -176,7 +176,7 @@ The generated code includes:
 
 3. **Run full application**:
    ```bash
-   ./docker-scripts.sh start-full
+   VEX_ENV=development ./docker-scripts.sh start-full
    ```
 
 ## Environment Variables
@@ -186,6 +186,7 @@ The generated code includes:
 - `AERON_EVENT_LOG=all` - Enable all event logging
 
 ### VEX Core
+- `VEX_ENV=development|test|production` - Required explicit environment selection
 - `RUST_LOG=info` - Rust logging level
 - `AERON_DIR=/tmp/aeron` - Aeron IPC directory (must match media driver)
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -38,6 +38,7 @@ services:
       sbe-generator:
         condition: service_completed_successfully
     environment:
+      - VEX_ENV
       - RUST_LOG=info
       - AERON_DIR=/tmp/aeron
     volumes:

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,9 @@
 use std::sync::atomic::Ordering;
 #[cfg(not(target_env = "msvc"))]
 use tikv_jemallocator::Jemalloc;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, info};
 use tracing_subscriber::fmt;
-use vex_config::{environment::Environment, VexConfig};
+use vex_config::VexConfig;
 
 #[cfg(not(target_env = "msvc"))]
 #[global_allocator]
@@ -14,11 +14,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     fmt::init();
 
     // Load configuration
-    let mut config = VexConfig::load_auto().or_else(|e| {
-        warn!("Failed to load configuration from files: {e}");
-        info!("Using default Test configuration");
-        Ok::<_, Box<dyn std::error::Error>>(VexConfig::new(Environment::Test))
-    })?;
+    let mut config = VexConfig::load_auto()?;
 
     config.core_networking.local_address = "0.0.0.0".to_string();
     config.core_networking.context_dir = "/dev/shm/aeron".to_string();

--- a/vex-config/src/environment.rs
+++ b/vex-config/src/environment.rs
@@ -18,9 +18,9 @@ pub enum Environment {
 }
 
 impl Environment {
-    /// Detect environment from environment variables
-    /// Checks VEX_ENV, ENVIRONMENT, ENV, and NODE_ENV in that order
-    pub fn detect() -> Self {
+    /// Detect an explicitly selected environment from environment variables.
+    /// Checks VEX_ENV, ENVIRONMENT, ENV, and NODE_ENV in that order.
+    pub fn detect_explicit() -> Option<Self> {
         let env_vars = ["VEX_ENV", "ENVIRONMENT", "ENV", "NODE_ENV"];
 
         for var in &env_vars {
@@ -33,8 +33,18 @@ impl Environment {
                     environment = %env,
                     source = *var
                 );
-                return env;
+                return Some(env);
             }
+        }
+
+        None
+    }
+
+    /// Detect environment from environment variables
+    /// Checks VEX_ENV, ENVIRONMENT, ENV, and NODE_ENV in that order
+    pub fn detect() -> Self {
+        if let Some(environment) = Self::detect_explicit() {
+            return environment;
         }
 
         tracing::warn!(

--- a/vex-config/src/error.rs
+++ b/vex-config/src/error.rs
@@ -36,6 +36,16 @@ pub enum ConfigError {
     #[error("Merge error: {0}")]
     MergeError(String),
 
+    /// Configuration load error with search-path context
+    #[error("Configuration load failed after trying paths {paths:?}: {source}")]
+    LoadError {
+        /// Paths searched for configuration files
+        paths: Vec<String>,
+        /// Underlying load failure
+        #[source]
+        source: Box<ConfigError>,
+    },
+
     /// Network configuration error
     #[error("Network configuration error: {0}")]
     NetworkError(String),
@@ -64,6 +74,14 @@ impl ConfigError {
     /// Create a new not found error
     pub fn not_found<S: Into<String>>(msg: S) -> Self {
         ConfigError::NotFound(msg.into())
+    }
+
+    /// Add searched paths to a configuration load error
+    pub fn load(paths: Vec<String>, source: ConfigError) -> Self {
+        ConfigError::LoadError {
+            paths,
+            source: Box::new(source),
+        }
     }
 
     /// Create a new network error

--- a/vex-config/src/lib.rs
+++ b/vex-config/src/lib.rs
@@ -66,8 +66,8 @@ impl VexConfig {
         }
     }
 
-    /// Load configuration using auto-detection of environment from ENV variables
-    /// Looks for VEX_ENV, ENVIRONMENT, or ENV environment variables
+    /// Load configuration using an explicitly selected environment
+    /// Looks for VEX_ENV, ENVIRONMENT, ENV, or NODE_ENV environment variables
     pub fn load_auto() -> Result<Self> {
         ConfigLoader::new().load_auto()
     }

--- a/vex-config/src/loader.rs
+++ b/vex-config/src/loader.rs
@@ -45,10 +45,40 @@ impl ConfigLoader {
         self
     }
 
-    /// Load configuration using auto-detection of environment
+    /// Load configuration using an explicitly selected environment
     pub fn load_auto(self) -> Result<VexConfig> {
-        let environment = Environment::detect();
-        self.load_for_environment(environment)
+        self.load_auto_for_environment(Environment::detect_explicit())
+    }
+
+    fn load_auto_for_environment(
+        self,
+        explicit_environment: Option<Environment>,
+    ) -> Result<VexConfig> {
+        let environment = explicit_environment.ok_or_else(|| {
+            ConfigError::EnvironmentError(
+                "No environment selected. Set one of VEX_ENV, ENVIRONMENT, ENV, or NODE_ENV to development, test, or production"
+                    .to_string(),
+            )
+        })?;
+
+        match self.load_for_environment(environment.clone()) {
+            Ok(config) => Ok(config),
+            Err(error) if environment.is_development() || environment.is_test() => {
+                tracing::warn!(
+                    target: "config",
+                    action = "config_load_failed",
+                    environment = %environment,
+                    error = %error
+                );
+                tracing::info!(
+                    target: "config",
+                    action = "using_environment_defaults",
+                    environment = %environment
+                );
+                Ok(VexConfig::new(environment))
+            }
+            Err(error) => Err(error),
+        }
     }
 
     /// Load configuration for a specific environment
@@ -90,7 +120,12 @@ impl ConfigLoader {
 
     /// Load configuration with optional environment and custom settings
     pub fn load_with_environment(self, environment: Option<Environment>) -> Result<VexConfig> {
-        let env = environment.unwrap_or_else(Environment::detect);
+        let env = environment.or_else(Environment::detect_explicit).ok_or_else(|| {
+            ConfigError::EnvironmentError(
+                "No environment selected. Set one of VEX_ENV, ENVIRONMENT, ENV, or NODE_ENV to development, test, or production"
+                    .to_string(),
+            )
+        })?;
 
         let mut builder = Config::builder();
 
@@ -107,7 +142,9 @@ impl ConfigLoader {
             let config_path = Path::new(path);
             if config_path.exists() {
                 files_found = true;
-                let format = self.detect_file_format(config_path)?;
+                let format = self
+                    .detect_file_format(config_path)
+                    .map_err(|error| ConfigError::load(search_paths.clone(), error))?;
                 builder = builder.add_source(File::from(config_path).format(format));
                 tracing::debug!(
                     target: "config",
@@ -154,13 +191,19 @@ impl ConfigLoader {
             );
         }
 
-        let config = builder.build()?;
-        let mut vex_config: VexConfig = config.try_deserialize()?;
+        let config = builder
+            .build()
+            .map_err(|error| ConfigError::load(search_paths.clone(), error.into()))?;
+        let mut vex_config: VexConfig = config
+            .try_deserialize()
+            .map_err(|error| ConfigError::load(search_paths.clone(), error.into()))?;
 
         // Ensure environment matches what we expect
         vex_config.environment = env;
 
-        vex_config.validate()?;
+        vex_config
+            .validate()
+            .map_err(|error| ConfigError::load(search_paths, error))?;
         Ok(vex_config)
     }
 
@@ -252,6 +295,64 @@ mod tests {
         let result = loader.load_from_file("nonexistent.toml");
         assert!(result.is_err());
         assert!(matches!(result.unwrap_err(), ConfigError::NotFound(_)));
+    }
+
+    #[test]
+    fn test_explicit_test_environment_allows_missing_file_defaults() {
+        let config = ConfigLoader::new()
+            .with_search_paths(vec!["/missing/config.test.yaml".to_string()])
+            .load_auto_for_environment(Some(Environment::Test))
+            .unwrap();
+
+        assert_eq!(config.environment, Environment::Test);
+    }
+
+    #[test]
+    fn test_explicit_development_environment_allows_missing_file_defaults() {
+        let config = ConfigLoader::new()
+            .with_search_paths(vec!["/missing/config.dev.yaml".to_string()])
+            .load_auto_for_environment(Some(Environment::Development))
+            .unwrap();
+
+        assert_eq!(config.environment, Environment::Development);
+    }
+
+    #[test]
+    fn test_explicit_environment_loads_present_config_file() {
+        let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("../config.dev.yaml");
+        let config = ConfigLoader::new()
+            .with_search_paths(vec![path.display().to_string()])
+            .load_auto_for_environment(Some(Environment::Development))
+            .unwrap();
+
+        assert_eq!(config.environment, Environment::Development);
+        assert!(!config.symbols.is_empty());
+    }
+
+    #[test]
+    fn test_explicit_production_environment_rejects_missing_files() {
+        let path = "/missing/config.prod.yaml";
+        let error = ConfigLoader::new()
+            .with_search_paths(vec![path.to_string()])
+            .load_auto_for_environment(Some(Environment::Production))
+            .unwrap_err();
+
+        assert!(error.to_string().contains(path));
+        assert!(error.to_string().contains("No configuration files found"));
+    }
+
+    #[test]
+    fn test_unset_environment_is_fatal() {
+        let error = ConfigLoader::new()
+            .load_auto_for_environment(None)
+            .unwrap_err();
+
+        let message = error.to_string();
+        assert!(message.contains("VEX_ENV"));
+        assert!(message.contains("ENVIRONMENT"));
+        assert!(message.contains("ENV"));
+        assert!(message.contains("NODE_ENV"));
+        assert!(message.contains("development, test, or production"));
     }
 
     // #[test]

--- a/vex-config/tests/integration_tests.rs
+++ b/vex-config/tests/integration_tests.rs
@@ -1,8 +1,11 @@
 //! Integration tests for VEX configuration
 
 use std::env;
+use std::sync::Mutex;
 use tempfile::TempDir;
 use vex_config::{ConfigError, ConfigLoader, Environment, VexConfig};
+
+static ENVIRONMENT_LOCK: Mutex<()> = Mutex::new(());
 
 #[test]
 fn test_basic_configuration_loading() {
@@ -94,7 +97,7 @@ fn test_file_loading_and_saving() -> Result<(), Box<dyn std::error::Error>> {
 #[test]
 fn test_different_file_formats() -> Result<(), Box<dyn std::error::Error>> {
     let temp_dir = TempDir::new()?;
-    let config = VexConfig::new(Environment::Production);
+    let config = VexConfig::new(Environment::Development);
 
     let toml_path = temp_dir.path().join("config.toml");
     let json_path = temp_dir.path().join("config.json");
@@ -111,9 +114,9 @@ fn test_different_file_formats() -> Result<(), Box<dyn std::error::Error>> {
     let yaml_config = VexConfig::load_from_file(&yaml_path)?;
 
     // All should have the same core values
-    assert_eq!(toml_config.environment, Environment::Production);
-    assert_eq!(json_config.environment, Environment::Production);
-    assert_eq!(yaml_config.environment, Environment::Production);
+    assert_eq!(toml_config.environment, Environment::Development);
+    assert_eq!(json_config.environment, Environment::Development);
+    assert_eq!(yaml_config.environment, Environment::Development);
 
     assert_eq!(
         toml_config.core_networking.core_id,
@@ -127,6 +130,38 @@ fn test_different_file_formats() -> Result<(), Box<dyn std::error::Error>> {
         yaml_config.core_networking.core_id,
         config.core_networking.core_id
     );
+
+    Ok(())
+}
+
+#[test]
+fn test_shipped_development_config_matches_defaults() -> Result<(), Box<dyn std::error::Error>> {
+    let config_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../config.dev.yaml");
+    let loaded = VexConfig::load_from_file(config_path)?;
+    let defaults = VexConfig::new(Environment::Development);
+
+    assert_eq!(
+        serde_json::to_value(loaded)?,
+        serde_json::to_value(defaults)?
+    );
+
+    Ok(())
+}
+
+#[test]
+fn test_load_error_names_path_and_parse_cause() -> Result<(), Box<dyn std::error::Error>> {
+    let temp_dir = TempDir::new()?;
+    let config_path = temp_dir.path().join("config.prod.yaml");
+    std::fs::write(&config_path, "invalid: [yaml")?;
+
+    let error = ConfigLoader::new()
+        .with_search_paths(vec![config_path.display().to_string()])
+        .load_for_environment(Environment::Production)
+        .unwrap_err()
+        .to_string();
+
+    assert!(error.contains(&config_path.display().to_string()));
+    assert!(error.contains("Parse error"));
 
     Ok(())
 }
@@ -315,6 +350,8 @@ fn test_logging_configuration() {
 
 #[test]
 fn test_environment_detection() {
+    let _guard = ENVIRONMENT_LOCK.lock().unwrap();
+
     // Clear all environment variables first to ensure clean test state
     unsafe {
         env::remove_var("VEX_ENV");
@@ -359,7 +396,7 @@ fn test_environment_detection() {
         env::remove_var("NODE_ENV");
     }
 
-    // Test fallback to development
+    // An unset environment is not an explicit selection and auto-loading must fail.
     unsafe {
         env::remove_var("VEX_ENV");
     }
@@ -372,30 +409,27 @@ fn test_environment_detection() {
     unsafe {
         env::remove_var("NODE_ENV");
     }
-    assert_eq!(Environment::detect(), Environment::Development);
+    assert_eq!(Environment::detect_explicit(), None);
+    let error = VexConfig::load_auto().unwrap_err().to_string();
+    assert!(error.contains("VEX_ENV"));
+    assert!(error.contains("ENVIRONMENT"));
+    assert!(error.contains("ENV"));
+    assert!(error.contains("NODE_ENV"));
+    assert!(error.contains("development, test, or production"));
 }
 
 #[test]
 fn test_auto_loading() {
-    // Set environment and test auto loading
+    let _guard = ENVIRONMENT_LOCK.lock().unwrap();
+
+    // Explicit development selects and loads the shipped config.dev.yaml.
     unsafe {
-        env::set_var("VEX_ENV", "test");
+        env::set_var("VEX_ENV", "development");
     }
 
-    let result = VexConfig::load_auto();
-
-    // Should either succeed or fail with NotFound (no config files)
-    match result {
-        Ok(config) => {
-            assert_eq!(config.environment, Environment::Test);
-        }
-        Err(ConfigError::NotFound(_)) => {
-            // Expected when no config files exist
-        }
-        Err(e) => {
-            panic!("Unexpected error during auto loading: {e}");
-        }
-    }
+    let config = VexConfig::load_auto().unwrap();
+    assert_eq!(config.environment, Environment::Development);
+    assert!(!config.symbols.is_empty());
 
     unsafe {
         env::remove_var("VEX_ENV");


### PR DESCRIPTION
## The problem

```rust
let mut config = VexConfig::load_auto().or_else(|e| {
    warn!("Failed to load configuration from files: {e}");
    info!("Using default Test configuration");
    Ok::<_, Box<dyn std::error::Error>>(VexConfig::new(Environment::Test))
})?;
```

A configuration load failure became a `warn!` and the engine ran on `Environment::Test`: **zero maker
and taker fees**, the ETH scaling that makes small orders free, and a BTC/USDT market typed
`FuturesContract` on a spot-only engine.

That was not a corner case — it was the only path the container had. `.gitignore` ended with blanket
`*.json` and `*.yaml` rules, so no config file could ever be committed, and there was none in the
tree. The `Dockerfile` does `COPY . .`. Every container that has ever run has silently used zero-fee
Test defaults.

Confirmed empirically while verifying #130 — a compose run logged exactly this:

```
WARN config: action="environment_defaulted"
WARN vex_core: Failed to load configuration from files: Configuration not found
INFO vex_core: Using default Test configuration
INFO vex_core: Loaded configuration for environment: test
```

## The fix

**A load failure is fatal unless the environment was explicitly selected as development or test.**
`main.rs` no longer swallows the error.

**The environment is never guessed.** `Environment::detect()` defaulted to Development with a warning
when none of `VEX_ENV` / `ENVIRONMENT` / `ENV` / `NODE_ENV` was set. `load_auto` now requires an
explicit selection and fails otherwise:

```
$ env -u VEX_ENV -u ENVIRONMENT -u ENV -u NODE_ENV cargo run --bin vex-core
Error: EnvironmentError("No environment selected. Set one of VEX_ENV, ENVIRONMENT, ENV, or NODE_ENV
to development, test, or production")
```

This part matters more than the fatal-on-failure guard, and it is why the first attempt at this fix
was wrong. Simply making failure fatal, then shipping a `config.dev.yaml`, would have left an unset
`VEX_ENV` resolving to Development, **successfully** loading a zero-fee file, and never tripping the
guard. The defect would have moved from a hidden default into a committed file. A matching engine
must not infer its own fee schedule.

**Errors name what was tried.** A load failure now reports all 12 search paths and the underlying
cause, so an operator can fix it without reading the source.

**`.gitignore` narrowed** from blanket `*.json` / `*.yaml` to `**/output.json`, `**/output.yaml` and
`**/recipe.json` — the generated example and cargo-chef outputs those rules were actually catching.
`target/`, `test-results/` and `.env` stay ignored, and no sensitive JSON or YAML exists in the tree.

**`config.dev.yaml` is committed** so the image carries a real configuration. Its values are copied
from the existing Development defaults — nothing invented. It carries zero fees, which is legitimate
for development, and is now reachable only via a deliberate `VEX_ENV=development`.

`RUNBOOK.md`, `docker/DOCKER_README.md` and `docker/docker-compose.yml` are updated so the documented
way of running the engine still works: compose passes an operator-supplied `VEX_ENV` through rather
than baking a choice into the image.

```
$ VEX_ENV=development cargo run --bin vex-core
INFO config: action="environment_detected" environment=development source="VEX_ENV"
DEBUG config: action="config_file_loaded" path=./config.dev.yaml
INFO server_main: action="config_validated"
```

`cargo test -p vex-config`: 40 passed, 0 failed. clippy: 0 warnings.

## Related

Closes #134

- vex-core #133 / PR #151 — validates the native scale factors, and adds the production empty-symbol
  guard. That guard is deliberately **not** duplicated here.
- vex-core #130 / PR #165 and #164 — the compose run that exposed this in the wild.
- vex-core #119 / PR #154 and #120 / PR #163 — fee arithmetic, which was moot while every container
  ran with zero fees.
