### PR TITLE
fix(engine): validate the pinning plan against the CPU affinity mask instead of panicking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3054,6 +3054,7 @@ name = "vex-server"
 version = "0.1.0"
 dependencies = [
  "common",
+ "core_affinity",
  "disruptor",
  "hashbrown 0.15.5",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ rusteron-client = "=0.1.157"
 rusteron-media-driver = "=0.1.157"
 rusteron-archive = "=0.1.157"
 disruptor = {git="https://github.com/trade-vex/disruptor-rs.git" , rev="7e07a8b0218d767d021925e58c5ff20fd5c30d70"}
+core_affinity = "0.8.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tracing = "0.1"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -21,6 +21,7 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 hashbrown = { workspace = true }
 disruptor = { workspace = true }
+core_affinity = { workspace = true }
 thiserror = { workspace = true }
 tikv-jemallocator = { workspace = true }
 

--- a/server/src/engine.rs
+++ b/server/src/engine.rs
@@ -125,6 +125,59 @@ impl Default for CorePinning {
     }
 }
 
+impl CorePinning {
+    fn core_ids(self) -> [usize; 14] {
+        [
+            self.journaling,
+            self.risk_engines[0],
+            self.risk_engines[1],
+            self.risk_engines[2],
+            self.risk_engines[3],
+            self.matching_engines[0],
+            self.matching_engines[1],
+            self.matching_engines[2],
+            self.matching_engines[3],
+            self.risk_r2_engines[0],
+            self.risk_r2_engines[1],
+            self.risk_r2_engines[2],
+            self.risk_r2_engines[3],
+            self.events,
+        ]
+    }
+
+    fn validate_available_cores(self, available_cores: &[usize]) -> EngineResult<()> {
+        let required_cores = self.core_ids();
+        let missing_cores: Vec<_> = required_cores
+            .iter()
+            .copied()
+            .filter(|core| !available_cores.contains(core))
+            .collect();
+
+        if missing_cores.is_empty() {
+            return Ok(());
+        }
+
+        Err(EngineError::Configuration(format!(
+            "Core pinning requires CPU cores {required_cores:?}, but the process CPU affinity mask allows {available_cores:?}; missing required cores {missing_cores:?}. Adjust the process cpuset or set ENABLE_CORE_PINNING=false to start without pinning"
+        )))
+    }
+
+    fn validate_process_affinity(self) -> EngineResult<()> {
+        let required_cores = self.core_ids();
+        let available_cores = core_affinity::get_core_ids()
+            .ok_or_else(|| {
+                EngineError::Configuration(format!(
+                    "Core pinning requires CPU cores {required_cores:?}, but the process CPU affinity mask could not be read. Set ENABLE_CORE_PINNING=false to start without pinning"
+                ))
+            })?
+            .into_iter()
+            .map(|core| core.id)
+            .collect::<Vec<_>>();
+
+        self.validate_available_cores(&available_cores)
+    }
+}
+
 /// High-performance exchange core engine
 ///
 /// This follows the exact same architecture as ExchangeCore:
@@ -162,7 +215,8 @@ impl CoreEngine {
     ///
     /// # Errors
     ///
-    /// Currently does not return errors, but signature allows for future error handling
+    /// Returns [`EngineError::Configuration`] when core pinning is enabled but the process CPU
+    /// affinity mask does not contain every configured core.
     pub fn new(
         symbol_specs: HashMap<u32, CoreMarketSpecification>,
         journaling_processor: JournalingProcessor,
@@ -171,6 +225,10 @@ impl CoreEngine {
         core_pinning: CorePinning,
         enable_pinning: bool,
     ) -> EngineResult<(Self, OrderProducer)> {
+        if enable_pinning {
+            core_pinning.validate_process_affinity()?;
+        }
+
         let (engine, producer) = Self::build_engine(
             symbol_specs,
             journaling_processor,
@@ -537,6 +595,46 @@ impl CoreEngine {
     #[must_use]
     pub fn publications(&self) -> &Arc<Publications> {
         &self.publications
+    }
+}
+
+#[cfg(test)]
+mod core_pinning_tests {
+    use super::*;
+
+    #[test]
+    fn exact_available_core_match_passes() {
+        let pinning = CorePinning::default();
+
+        assert!(
+            pinning
+                .validate_available_cores(&pinning.core_ids())
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn missing_available_core_fails_and_names_it() {
+        let error = CorePinning::default()
+            .validate_available_cores(&[1, 2, 3, 4, 5, 6, 7, 9, 10, 11, 12, 13, 14])
+            .expect_err("core 8 should be required");
+        let message = error.to_string();
+
+        assert!(
+            message.contains("requires CPU cores [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]")
+        );
+        assert!(message.contains("affinity mask allows [1, 2, 3, 4, 5, 6, 7, 9"));
+        assert!(message.contains("missing required cores [8]"));
+        assert!(message.contains("ENABLE_CORE_PINNING=false"));
+    }
+
+    #[test]
+    fn available_core_superset_passes() {
+        assert!(
+            CorePinning::default()
+                .validate_available_cores(&[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
+                .is_ok()
+        );
     }
 }
 


### PR DESCRIPTION
## The problem

`CorePinning::default` hard-codes cores 1 through 14. The pinned `disruptor` fork's `pin_at_core`
calls `cpu_has_core_else_panic(id)`, so under `--cpuset-cpus` or a Kubernetes CPU limit,
`pin_at_core(8)` **panics partway through building the pipeline** — before any port is bound, with
nothing but a panic line on stdout. That is a total outage on every pod start, and nothing verified
that pinning had succeeded.

## The fix

A preflight check in `CoreEngine::new`, before the pipeline is built: every one of the 14 configured
cores must be present in the process's CPU affinity mask. On a mismatch it returns
`EngineError::Configuration` naming the cores required, the cores available, the ones missing, and
`ENABLE_CORE_PINNING=false` as the way to start without pinning.

The mask comes from `core_affinity::get_core_ids()` (`sched_getaffinity` on Linux). That crate is
already in the tree transitively via the `disruptor` fork — this promotes it to a direct dependency
of `server` and adds no new crate to `Cargo.lock`. If the mask cannot be read at all, that is also an
error rather than an assumption that pinning will work.

All 14 assignments are checked, not just the first, so the error names every missing core at once
instead of surfacing them one restart at a time.

**Pinning is not silently disabled when cores are missing.** That was the tempting fix and it is the
wrong one: pinning is a deliberate choice on a latency-sensitive path, and quietly ignoring it would
turn a serious misconfiguration into a silent performance cliff. The operator either fixes the cpuset
or turns pinning off explicitly.

`cargo test -p vex-server`: 11 passed, 0 failed — including an exact core-set match, a missing core
(the message names it), and an available superset. clippy: 0 warnings.

## Related

Closes #136

- vex-core #129 / PR #156 — a panic on a pipeline handler thread. This closes the startup-time
  variant of the same failure mode: a panic where an error was the right answer.
- vex-core #130 / PR #165 — container health, where a panicking start is invisible beyond the pod
  restarting.
