### PR TITLE
fix(events): stop a cached Schema Registry failure from killing a topic permanently

### DIFF
--- a/processors/src/events.rs
+++ b/processors/src/events.rs
@@ -11,8 +11,9 @@ use common::{base_asset, order_debug, order_info, quote_asset};
 use prost::Message;
 use rdkafka::config::ClientConfig;
 use rdkafka::producer::{FutureProducer, FutureRecord, Producer};
-use schema_registry_converter::async_impl::easy_proto_raw::EasyProtoRawEncoder;
+use schema_registry_converter::async_impl::proto_raw::ProtoRawEncoder;
 use schema_registry_converter::async_impl::schema_registry::SrSettings;
+use schema_registry_converter::error::SRCError;
 use schema_registry_converter::schema_registry_common::{
     SchemaType, SubjectNameStrategy, SuppliedSchema,
 };
@@ -40,10 +41,15 @@ pub trait EventsHandler: Send + Sync + 'static {
     fn handle_processed_command(&self, cmd: &mut OrderCommand);
 }
 
+fn should_retry_schema_registration(error: &SRCError) -> bool {
+    error.cached
+}
+
 // Real Kafka Events Handler
 pub struct KafkaEventsHandler {
     producer: FutureProducer,
-    encoder: Arc<EasyProtoRawEncoder>,
+    encoder: Arc<ProtoRawEncoder<'static>>,
+    schema: Arc<SuppliedSchema>,
     publications: Arc<Publications>,
     replay_control: ReplayControl,
     rt: Arc<Runtime>,
@@ -66,7 +72,15 @@ impl KafkaEventsHandler {
 
         // Initialize Schema Registry Encoder
         let sr_settings = SrSettings::new(schema_registry_url.to_string());
-        let encoder = Arc::new(EasyProtoRawEncoder::new(sr_settings));
+        let encoder = Arc::new(ProtoRawEncoder::new(sr_settings));
+        let schema = Arc::new(SuppliedSchema {
+            name: None,
+            schema_type: SchemaType::Protobuf,
+            schema: TRADING_SCHEMA.to_string(),
+            references: vec![],
+            properties: None,
+            tags: None,
+        });
 
         // Create a dedicated runtime for async tasks
         let rt = Arc::new(Runtime::new().expect("Failed to create tokio runtime"));
@@ -82,6 +96,7 @@ impl KafkaEventsHandler {
         Self {
             producer,
             encoder,
+            schema,
             publications,
             replay_control,
             rt,
@@ -96,6 +111,7 @@ impl KafkaEventsHandler {
         data: T,
     ) {
         let encoder = self.encoder.clone();
+        let schema = self.schema.clone();
         let producer = self.producer.clone();
         let topic = topic_name.to_string();
         let key_str = message_key.to_string();
@@ -106,34 +122,33 @@ impl KafkaEventsHandler {
             // Serialize data to bytes using Prost
             let payload_bytes = data.encode_to_vec();
 
-            // Create SuppliedSchema with the .proto content for Schema Registry
-            let supplied_schema = SuppliedSchema {
-                name: Some(full_name.clone()),
-                schema_type: SchemaType::Protobuf,
-                schema: TRADING_SCHEMA.to_string(),
-                references: vec![],
-                properties: None,
-                tags: None,
-            };
-
             // Encode with schema registration (magic byte + schema ID)
             // Use TopicNameStrategyWithSchema so schema is registered as "<topic>-value"
             // This ensures Kafka Connect (JDBC Sink) can find the schema
             let strategy = SubjectNameStrategy::TopicNameStrategyWithSchema(
                 topic.clone(),
                 false,
-                supplied_schema,
+                schema.as_ref().clone(),
             );
+            let subject = format!("{topic}-value");
 
             let encoded_payload = match encoder.encode(&payload_bytes, &full_name, strategy).await {
                 Ok(bytes) => bytes,
                 Err(e) => {
+                    let retry_later = should_retry_schema_registration(&e);
+                    if retry_later {
+                        encoder.remove_errors_from_cache();
+                    }
                     error!(
                         target: "events",
                         component = "kafka_handler",
                         action = "protobuf_encoding_failed",
                         topic = %topic,
-                        error = ?e
+                        subject = %subject,
+                        error = %e.error,
+                        cause = ?e.cause,
+                        retriable = e.retriable,
+                        retry_later
                     );
                     return;
                 }
@@ -695,6 +710,21 @@ mod tests {
     use common::{Side, UserBalance};
 
     const MARKET_ID: u32 = 100_000_010; // Example market_id encoding
+
+    #[test]
+    fn cached_schema_registration_failure_is_retried_later() {
+        let error = SRCError::retryable_with_cause("registry unavailable", "registration failed")
+            .into_cache();
+
+        assert!(should_retry_schema_registration(&error));
+    }
+
+    #[test]
+    fn uncached_encoding_failure_does_not_reset_registration() {
+        let error = SRCError::non_retryable_without_cause("invalid protobuf message name");
+
+        assert!(!should_retry_schema_registration(&error));
+    }
 
     #[test]
     fn test_kafka_events_handler_placed_order() {


### PR DESCRIPTION
## The problem

The fire-and-forget publish path built a `SuppliedSchema` and registered it on **every** message.

`schema_registry_converter` 4.7.0 caches per subject — and it caches **failures** as well as
successes: a successful registration lands in `direct_cache`, a failed one is stored as a failed
shared future in `cache`, and the easy encoder exposes no way to evict it. So the first message on a
topic that happened to coincide with a Schema Registry blip poisoned that subject **for the lifetime
of the process**. Every subsequent event on that topic was dropped, and the only trace was an
`error = ?e` debug-formatted log with no subject and no indication that the condition was permanent.

Worth recording precisely, because the original report was half right: successful registration was
already memoised, so the per-message `SuppliedSchema` construction was waste rather than a
correctness bug. The correctness bug was the cached *failure*.

## The fix

- The `SuppliedSchema` is built **once**, at handler construction, and shared.
- The encoder moves from `EasyProtoRawEncoder` to `ProtoRawEncoder`, which exposes
  `remove_errors_from_cache()`. On an encode failure whose error is flagged `cached`, the poisoned
  entry is evicted so the next message retries. A non-cached failure — a genuinely invalid message
  name, say — is left alone, because retrying it would never help.
- Every dropped message now logs a structured `error!` with the topic, the derived subject
  (`<topic>-value`), the cause, and whether it will be retried. Every time, not once.

`SuppliedSchema.name` goes from `Some(full_name)` to `None`, which is behaviour-identical here and
worth stating since it looks like a semantic change: for `TopicNameStrategyWithSchema`,
`get_subject` derives the subject purely from the topic, and the registration request body carries
only `schema`, `schemaType`, `references`, properties and tags. The `name` field is read solely by
the `RecordName` strategies, which this code does not use. `full_name` is still passed to `encode`
where it does matter.

## Threading

Checked before adding anything: `handle_processed_command` runs on the disruptor event stage, but the
Schema Registry and Kafka work is already dispatched onto a dedicated Tokio runtime via
`Runtime::spawn`. So the pipeline is not on this path — and deliberately, **no sleep and no blocking
retry loop was added** regardless. Recovery is "the next message retries", which costs nothing when
there is no next message.

A Schema Registry failure is also deliberately **not** fatal. Unlike a lost journal record (#116), a
dropped event message is not a correctness violation for the matching engine, and taking the exchange
down for it would be worse than the bug.

One consequence to be aware of: under a sustained registry outage, every message evicts the error
cache and re-attempts registration, so the outage is retried at message rate rather than backing off.
That is the deliberate trade for never being permanently poisoned, and it happens off the pipeline.

`cargo test -p processors`: 16 passed, 0 failed. clippy: 0 warnings.

## Related

Closes #124

- vex-core #78 — the per-event thread spawn in the Kafka publisher, deliberately untouched here.
- vex-core #116 / PR #159 — the same fire-and-forget shape on the archive path, where the answer is
  the opposite: there, a lost write **is** a correctness violation and does abort.
