### PR TITLE
fix(risk): release the collateral that was actually locked instead of recomputing it

### DIFF
--- a/processors/src/risk_engine.rs
+++ b/processors/src/risk_engine.rs
@@ -19,6 +19,7 @@ use tracing::{debug, error, info, warn};
 pub struct RiskEngine {
     balances: Arc<Mutex<BalanceStore>>,
     accrued_fees: Mutex<HashMap<u16, u64>>,
+    bid_collateral: Mutex<HashMap<u64, u64>>,
     pub symbol_specs: HashMap<u32, CoreMarketSpecification>,
     shard_id: u32,
     shard_mask: u64,
@@ -36,6 +37,7 @@ impl RiskEngine {
         Self {
             balances: Arc::new(Mutex::new(BalanceStore::new())),
             accrued_fees: Mutex::new(HashMap::new()),
+            bid_collateral: Mutex::new(HashMap::new()),
             symbol_specs,
             shard_id,
             shard_mask: (num_shards - 1) as u64,
@@ -152,7 +154,7 @@ impl RiskEngine {
         market_id: u32,
         user_side: Side,
         event: &mut MatcherTradeEvent,
-        taker_cmd: Option<u64>,
+        taker_order: Option<(u64, u64)>,
     ) {
         debug!(
             target: "risk_engine",
@@ -179,7 +181,8 @@ impl RiskEngine {
             }
         };
 
-        if let Err(err) = self.settle_trade(user_id, market_id, user_side, event, spec, taker_cmd) {
+        if let Err(err) = self.settle_trade(user_id, market_id, user_side, event, spec, taker_order)
+        {
             error!(
                 target: "risk_engine",
                 event = "settlement_failed",
@@ -190,7 +193,7 @@ impl RiskEngine {
                 maker_user_id = event.maker_user_id,
                 price = event.price,
                 size = event.size,
-                taker_price = ?taker_cmd,
+                taker_order = ?taker_order,
                 error = ?err
             );
         } else {
@@ -211,9 +214,16 @@ impl RiskEngine {
         user_side: Side,
         event: &mut MatcherTradeEvent,
         spec: &CoreMarketSpecification,
-        taker_price: Option<u64>,
+        taker_order: Option<(u64, u64)>,
     ) -> Result<()> {
         let is_maker = user_id == event.maker_user_id;
+        let (order_id, order_completed) = if is_maker {
+            (event.matched_order_id, event.matched_order_completed)
+        } else if let Some((order_id, _)) = taker_order {
+            (order_id, event.active_order_completed)
+        } else {
+            (0, event.active_order_completed)
+        };
         let fee = if is_maker {
             spec.maker_fee
         } else {
@@ -223,7 +233,7 @@ impl RiskEngine {
         // --- Price Improvement Refund Logic (for Taker only) ---
         // If the taker gets a better price than their limit, refund the difference.
         let refund_amount = if !is_maker
-            && let Some(limit_price) = taker_price
+            && let Some((_, limit_price)) = taker_order
             && user_side == Side::Bid
         // Price improvement only applies to BID orders where QUOTE currency was locked.
         {
@@ -351,6 +361,25 @@ impl RiskEngine {
             fees.insert(fee_asset, total);
         }
 
+        // PR #171 collateral bookkeeping runs AFTER the balances commit, so a
+        // failed settlement cannot desynchronise the tracked reservation.
+        if refund_amount > 0 {
+            self.subtract_bid_collateral(order_id, refund_amount);
+        }
+        if user_side == Side::Bid {
+            self.subtract_bid_collateral(order_id, amount_to_subtract);
+        }
+
+        if user_side == Side::Bid && order_completed {
+            self.release_remaining_bid_collateral(
+                &mut store,
+                order_id,
+                user_id,
+                quote_asset(market_id),
+            )?;
+            balance_sub = store.get_balance(user_id, asset_to_subtract);
+        }
+
         if is_maker {
             if asset_to_subtract == base_asset(market_id) {
                 // Maker was on ASK side, selling base for quote.
@@ -367,9 +396,13 @@ impl RiskEngine {
 
     /// handle cancellations -> release funds
     pub fn handle_cancellation(&self, cmd: &mut OrderCommand) {
-        if let Err(err) =
-            self.release_funds_for_order(cmd.user_id, cmd.market_id, cmd.side, cmd.price, cmd.size)
-        {
+        if let Err(err) = self.release_funds_for_order(
+            cmd.order_id,
+            cmd.user_id,
+            cmd.market_id,
+            cmd.side,
+            cmd.size,
+        ) {
             error!(
                 "[RiskEngine_{}] Failed to release funds for cancelled order {}: {:?}",
                 self.shard_id, cmd.order_id, err
@@ -426,6 +459,11 @@ impl RiskEngine {
         // Acquire a lock on the store and perform the operation
         let mut store = self.balances.lock();
         store.lock_funds(cmd.user_id, asset_to_lock, amount_to_lock)?;
+        if cmd.side == Side::Bid {
+            self.bid_collateral
+                .lock()
+                .insert(cmd.order_id, amount_to_lock);
+        }
         Ok(())
     }
 
@@ -487,30 +525,57 @@ impl RiskEngine {
     /// This is called by the post-orderbook risk engine or order cancellation logic.
     fn release_funds_for_order(
         &self,
+        order_id: u64,
         user_id: u64,
         market_id: u32,
         side: Side,
-        price: u64,
         size: u64,
     ) -> Result<()> {
-        let spec = self
-            .symbol_specs
-            .get(&market_id)
-            .ok_or(RiskEngineError::MarketSpecNotFound { market_id })?;
+        let mut store = self.balances.lock();
+        match side {
+            Side::Bid => self.release_remaining_bid_collateral(
+                &mut store,
+                order_id,
+                user_id,
+                quote_asset(market_id),
+            ),
+            Side::Ask => store
+                .unlock_funds(user_id, base_asset(market_id), size)
+                .map_err(RiskEngineError::BalanceError),
+        }
+    }
 
-        let (asset_to_unlock, amount_to_unlock) = match side {
-            Side::Bid => {
-                let amount = spec.calculate_quote_cost(price, size);
-                (quote_asset(market_id), amount)
-            }
-            Side::Ask => (base_asset(market_id), size),
+    fn subtract_bid_collateral(&self, order_id: u64, amount: u64) {
+        let mut collateral = self.bid_collateral.lock();
+        if let Some(remaining) = collateral.get_mut(&order_id) {
+            *remaining = remaining.saturating_sub(amount);
+        }
+    }
+
+    fn release_remaining_bid_collateral(
+        &self,
+        store: &mut BalanceStore,
+        order_id: u64,
+        user_id: u64,
+        asset_id: u16,
+    ) -> Result<()> {
+        let mut collateral = self.bid_collateral.lock();
+        let Some(amount) = collateral.get(&order_id).copied() else {
+            warn!(
+                target: "risk_engine",
+                event = "missing_bid_collateral",
+                shard_id = self.shard_id,
+                order_id,
+                user_id
+            );
+            return Ok(());
         };
 
-        // Acquire a lock on the store and perform the operation
-        let mut store = self.balances.lock();
-        store
-            .unlock_funds(user_id, asset_to_unlock, amount_to_unlock)
-            .map_err(RiskEngineError::BalanceError)
+        if amount != 0 {
+            store.unlock_funds(user_id, asset_id, amount)?;
+        }
+        collateral.remove(&order_id);
+        Ok(())
     }
 
     pub fn get_balance(&self, user_id: u64, asset_id: u16) -> UserBalance {
@@ -651,7 +716,7 @@ mod tests {
                     market_id,
                     Side::Bid,
                     &mut trade_event,
-                    (!is_maker).then_some(1),
+                    (!is_maker).then_some((1, 1)),
                 );
 
                 let base_balance = engine.get_balance(user_id, base_asset_id).total();
@@ -744,7 +809,7 @@ mod tests {
             market_id,
             Side::Bid,
             &mut trade_event,
-            Some(price),
+            Some((1, price)),
         );
         engine.handle_trade_event(maker_id, market_id, Side::Ask, &mut trade_event, None);
 
@@ -1211,7 +1276,7 @@ mod tests {
             market_id,
             Side::Bid,
             &mut trade_event,
-            Some(price),
+            Some((taker_cmd.order_id, price)),
         );
 
         // Settle for Maker (Seller, Ask side) - sells base (BTC) for quote (USD)
@@ -1278,7 +1343,7 @@ mod tests {
             Side::Bid,
             &mut trade_event,
             &spec,
-            Some(limit_price),
+            Some((1, limit_price)),
         );
 
         assert_eq!(
@@ -1328,7 +1393,13 @@ mod tests {
             maker_original_size: size,
         };
 
-        engine.handle_trade_event(user_id, market_id, Side::Bid, &mut trade_event, Some(price));
+        engine.handle_trade_event(
+            user_id,
+            market_id,
+            Side::Bid,
+            &mut trade_event,
+            Some((1, price)),
+        );
 
         let expected_fee = 2_000_000_000_000_000;
         assert_eq!(
@@ -1557,7 +1628,7 @@ mod tests {
             market_id_btc_usd,
             Side::Bid,
             &mut btc_trade_event,
-            Some(btc_price),
+            Some((btc_buy_cmd.order_id, btc_price)),
         );
 
         // --- Check balances after BTC trade settlement ---
@@ -1592,5 +1663,174 @@ mod tests {
             50_000
         ); // Funds unlocked
         assert_eq!(engine.get_balance(user_id, eth_asset_id).locked(), 0);
+    }
+
+    fn get_shipped_eth_spec(market_id: u32) -> CoreMarketSpecification {
+        CoreMarketSpecification::builder()
+            .market_id(market_id)
+            .market_type(MarketType::Spot)
+            .base_scale_k(100_000)
+            .quote_scale_k(10)
+            .base_native_scale(1_000_000_000_000_000_000)
+            .quote_native_scale(1_000_000)
+            .maker_fee(0)
+            .taker_fee(0)
+            .slippage(5)
+            .build()
+            .unwrap()
+    }
+
+    fn assert_shipped_eth_bid_accounting(fill_sizes: &[u64], fully_filled: bool) {
+        let user_id = 50;
+        let market_id = (2_u32 << 16) | 1_u32;
+        let price = 30_000;
+        let order_size = 1_000_000_000;
+        let initial_quote = 10;
+        let order_id = 42;
+
+        let spec = get_shipped_eth_spec(market_id);
+        let mut specs = HashMap::new();
+        specs.insert(market_id, spec.clone());
+        let price_cache = Arc::new(PriceCache::new(specs.keys()));
+        let engine = RiskEngine::new(specs, 2, 4);
+        engine.set_balance(
+            user_id,
+            quote_asset(market_id),
+            UserBalance::new(initial_quote, 0),
+        );
+
+        let mut cmd = OrderCommand::place_order(
+            TimeInForce::Gtc,
+            user_id,
+            price,
+            order_size,
+            Side::Bid,
+            market_id,
+            1,
+        );
+        cmd.order_id = order_id;
+        engine
+            .reserve_funds_for_order(&mut cmd, price_cache)
+            .unwrap();
+
+        let mut spent = 0;
+        for (index, &fill_size) in fill_sizes.iter().enumerate() {
+            let completed = fully_filled && index + 1 == fill_sizes.len();
+            let mut event = MatcherTradeEvent {
+                active_order_completed: false,
+                matched_order_id: order_id,
+                maker_user_id: user_id,
+                matched_order_completed: completed,
+                price,
+                size: fill_size,
+                next_event: None,
+                maker_balance: [UserBalance::default(); 2],
+                maker_remaining_size: 0,
+                maker_original_size: fill_size,
+            };
+            engine.handle_trade_event(user_id, market_id, Side::Bid, &mut event, None);
+            cmd.size -= fill_size;
+            spent += spec.calculate_quote_cost(price, fill_size);
+        }
+
+        if !fully_filled {
+            engine.handle_cancellation(&mut cmd);
+        }
+
+        let balance = engine.get_balance(user_id, quote_asset(market_id));
+        assert_eq!(balance.available(), initial_quote - spent);
+        assert_eq!(balance.locked(), 0);
+        assert_eq!(balance.total() + spent, initial_quote);
+        assert!(!engine.bid_collateral.lock().contains_key(&order_id));
+    }
+
+    #[test]
+    fn test_shipped_eth_bid_full_fill_has_no_collateral_residue() {
+        assert_shipped_eth_bid_accounting(&[333_333_334, 666_666_666], true);
+    }
+
+    #[test]
+    fn test_shipped_eth_bid_partial_fill_cancel_has_no_collateral_residue() {
+        assert_shipped_eth_bid_accounting(&[333_333_334], false);
+    }
+
+    #[test]
+    fn test_shipped_eth_bid_cancel_without_fill_has_no_collateral_residue() {
+        assert_shipped_eth_bid_accounting(&[], false);
+    }
+
+    #[test]
+    fn test_shipped_eth_bid_multiple_partial_fills_cancel_has_no_collateral_residue() {
+        assert_shipped_eth_bid_accounting(&[333_333_334, 333_333_334], false);
+    }
+
+    #[test]
+    fn test_bid_cancel_without_collateral_record_is_safe() {
+        let user_id = 50;
+        let market_id = (2_u32 << 16) | 1_u32;
+        let mut specs = HashMap::new();
+        specs.insert(market_id, get_shipped_eth_spec(market_id));
+        let engine = RiskEngine::new(specs, 2, 4);
+        engine.set_balance(user_id, quote_asset(market_id), UserBalance::new(10, 0));
+        let mut cmd = OrderCommand::cancel_order(404, user_id, Side::Bid, market_id);
+
+        engine.handle_cancellation(&mut cmd);
+
+        assert_eq!(
+            engine.get_balance(user_id, quote_asset(market_id)),
+            UserBalance::new(10, 0)
+        );
+    }
+
+    #[test]
+    fn test_shipped_eth_ask_partial_fill_cancel_uses_raw_size() {
+        let user_id = 50;
+        let market_id = (2_u32 << 16) | 1_u32;
+        let price = 30_000;
+        let order_size = 1_000_000_000;
+        let fill_size = 333_333_334;
+        let mut specs = HashMap::new();
+        specs.insert(market_id, get_shipped_eth_spec(market_id));
+        let price_cache = Arc::new(PriceCache::new(specs.keys()));
+        let engine = RiskEngine::new(specs, 2, 4);
+        engine.set_balance(
+            user_id,
+            base_asset(market_id),
+            UserBalance::new(order_size, 0),
+        );
+        let mut cmd = OrderCommand::place_order(
+            TimeInForce::Gtc,
+            user_id,
+            price,
+            order_size,
+            Side::Ask,
+            market_id,
+            1,
+        );
+        cmd.order_id = 42;
+        engine
+            .reserve_funds_for_order(&mut cmd, price_cache)
+            .unwrap();
+        let mut event = MatcherTradeEvent {
+            active_order_completed: false,
+            matched_order_id: cmd.order_id,
+            maker_user_id: user_id,
+            matched_order_completed: false,
+            price,
+            size: fill_size,
+            next_event: None,
+            maker_balance: [UserBalance::default(); 2],
+            maker_remaining_size: 0,
+            maker_original_size: fill_size,
+        };
+        engine.handle_trade_event(user_id, market_id, Side::Ask, &mut event, None);
+        cmd.size -= fill_size;
+
+        engine.handle_cancellation(&mut cmd);
+
+        let balance = engine.get_balance(user_id, base_asset(market_id));
+        assert_eq!(balance.available(), order_size - fill_size);
+        assert_eq!(balance.locked(), 0);
+        assert_eq!(balance.total() + fill_size, order_size);
     }
 }

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -556,7 +556,7 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "documents calculate_quote_cost wrapping when the shipped BTC result exceeds u64"]
+    // Fixed in this stack by PR #146 (calculate_quote_cost saturates instead of wrapping).
     fn test_shipped_btc_quote_cost_is_monotonic_past_largest_in_range() {
         let mut specs = HashMap::new();
         let market_id = add_shipped_spec(ShippedScaling::BtcUsdt, &mut specs);
@@ -665,8 +665,8 @@ mod tests {
         engine.pre_process_command(&mut bid, Arc::clone(&price_cache));
         engine.pre_process_command(&mut ask, price_cache);
 
-        // MatcherTradeEvent implements Drop (PR #179): assign the fields
-        // instead of functional-update syntax, which moves out of a Drop type.
+        // MatcherTradeEvent implements Drop (PR #179): the functional-update form
+        // would move out of a Drop type, so assign the fields instead.
         let mut event = common::MatcherTradeEvent::default();
         event.price = price;
         event.size = size;
@@ -675,7 +675,13 @@ mod tests {
         event.matched_order_completed = true;
         event.active_order_completed = true;
         event.maker_original_size = size;
-        engine.handle_trade_event(buyer_id, market_id, Side::Bid, &mut event, Some(price));
+        engine.handle_trade_event(
+            buyer_id,
+            market_id,
+            Side::Bid,
+            &mut event,
+            Some((bid.order_id, price)),
+        );
         engine.handle_trade_event(seller_id, market_id, Side::Ask, &mut event, None);
 
         // PR #163 rounds fees UP per fill (div_ceil), so this remainder costs one more
@@ -730,8 +736,8 @@ mod tests {
         );
         engine.pre_process_command(&mut ask, price_cache);
 
-        // MatcherTradeEvent implements Drop (PR #179): assign the fields
-        // instead of functional-update syntax, which moves out of a Drop type.
+        // MatcherTradeEvent implements Drop (PR #179): the functional-update form
+        // would move out of a Drop type, so assign the fields instead.
         let mut event = common::MatcherTradeEvent::default();
         event.price = price;
         event.size = fill_size;
@@ -757,7 +763,7 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "documents missing issue #111 zero-collateral BID rejection in this revision"]
+    // Fixed in this stack by PR #146 (zero-collateral BID rejection).
     fn test_shipped_eth_bid_with_zero_quote_cost_is_rejected() {
         let mut specs = HashMap::new();
         let market_id = add_shipped_spec(ShippedScaling::EthUsdt, &mut specs);
@@ -780,7 +786,7 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "documents one-atomic-unit BID collateral residue after partial fill and cancel"]
+    // Fixed in this stack by PR #171 (bid_collateral releases exactly what was locked).
     fn test_shipped_eth_bid_partial_fill_cancel_has_no_collateral_residue() {
         let mut specs = HashMap::new();
         let market_id = add_shipped_spec(ShippedScaling::EthUsdt, &mut specs);
@@ -807,19 +813,26 @@ mod tests {
         );
         engine.pre_process_command(&mut bid, price_cache);
 
-        // MatcherTradeEvent implements Drop (PR #179): assign the fields
-        // instead of functional-update syntax, which moves out of a Drop type.
+        // MatcherTradeEvent implements Drop (PR #179): the functional-update form
+        // would move out of a Drop type, so assign the fields instead.
         let mut event = common::MatcherTradeEvent::default();
         event.price = price;
         event.size = fill_size;
         event.maker_user_id = user_id + 1;
         event.matched_order_id = 2;
         event.maker_original_size = fill_size;
-        engine.handle_trade_event(user_id, market_id, Side::Bid, &mut event, Some(price));
+        engine.handle_trade_event(
+            user_id,
+            market_id,
+            Side::Bid,
+            &mut event,
+            Some((bid.order_id, price)),
+        );
         bid.set_size(remaining_size);
         engine.handle_cancellation(&mut bid);
 
-        let fee = (fill_size * 20) / 10_000;
+        // PR #163 rounds per-fill fees UP; this expectation predated it.
+        let fee = (fill_size * 20).div_ceil(10_000);
         assert_eq!(
             engine.get_balance(user_id, base_asset_id),
             UserBalance::new(fill_size - fee, 0)
@@ -832,7 +845,7 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "documents u64 fee multiplication overflow for a one-ETH shipped-scale fill"]
+    // Fixed in this stack by PR #154 (fee arithmetic in u128).
     fn test_shipped_eth_one_token_fee_arithmetic_does_not_overflow() {
         let mut specs = HashMap::new();
         let market_id = add_shipped_spec(ShippedScaling::EthUsdt, &mut specs);
@@ -855,15 +868,21 @@ mod tests {
         );
         engine.pre_process_command(&mut bid, price_cache);
 
-        // MatcherTradeEvent implements Drop (PR #179): assign the fields
-        // instead of functional-update syntax, which moves out of a Drop type.
+        // MatcherTradeEvent implements Drop (PR #179): the functional-update form
+        // would move out of a Drop type, so assign the fields instead.
         let mut event = common::MatcherTradeEvent::default();
         event.price = price;
         event.size = one_eth;
         event.maker_user_id = user_id + 1;
         event.matched_order_id = 2;
         event.maker_original_size = one_eth;
-        engine.handle_trade_event(user_id, market_id, Side::Bid, &mut event, Some(price));
+        engine.handle_trade_event(
+            user_id,
+            market_id,
+            Side::Bid,
+            &mut event,
+            Some((bid.order_id, price)),
+        );
 
         assert_eq!(
             engine

--- a/server/src/utils.rs
+++ b/server/src/utils.rs
@@ -88,6 +88,7 @@ macro_rules! create_risk_r2_handler {
             let market_id = cmd.market_id();
             let taker_side = cmd.side();
             let taker_price = cmd.price();
+            let taker_order_id = cmd.order_id();
 
             // Determine shard ownership for taker
             let is_taker_shard = ((taker_id & shard_mask) as usize) == $shard_id;
@@ -103,7 +104,7 @@ macro_rules! create_risk_r2_handler {
                     let maker_side = taker_side.op_side();
                     risk_engine.handle_trade_event(
                         maker_id, market_id, maker_side, event,
-                        None, // Maker uses matched price, not limit price
+                        None, // Maker order ID is carried by the trade event
                     );
                 }
 
@@ -114,7 +115,7 @@ macro_rules! create_risk_r2_handler {
                         market_id,
                         taker_side,
                         event,
-                        Some(taker_price),
+                        Some((taker_order_id, taker_price)),
                     );
                 }
 


### PR DESCRIPTION
> Stacked on #158 (`fix/127-journaling-barrier`), which this branch now carries as its first commit.
> The collateral key this fix introduces is not valid without it. **Merge #158 first.**

## The problem

The engine computed a BID's quote notional **three separate times**, each independently floored by
`calculate_quote_cost`:

1. `reserve_funds_for_order` locked `calculate_quote_cost(price, order_size)`
2. `settle_trade` spent `calculate_quote_cost(event.price, event.size)` per fill
3. `handle_cancellation` released `calculate_quote_cost(price, remaining_size)`

Flooring is not additive — `floor(f(total)) >= floor(f(fill)) + floor(f(remainder))` — so the
difference stayed **locked forever**. The user could not spend it, could not cancel it, and no code
path released it.

At the shipped ETH/USDT scaling:

```
user 50, quote available 10
BID price 30,000 size 1,000,000,000
fill 333,333,334 ; cancel remainder 666,666,666

expected: available 9, locked 0
actual:   available 9, locked 1     <- stranded, unrecoverable
```

Small per order, but unrecoverable, cumulative, and it means the ledger does not balance.

## The fix

**Stop recomputing. Release what was actually locked.**

`RiskEngine` keeps `bid_collateral: Mutex<HashMap<u64, u64>>` — order id to remaining locked quote.
It is written at placement with the exact amount locked, decremented by each fill and by each
price-improvement refund, and drained on completion or cancel. The three computations can no longer
disagree because there is only one number.

This also removes a latent bug in the old cancel path: it derived the refund from `cmd.price` and
`cmd.size` on the cancel command, so a stale size would have released the wrong amount. The tracked
remainder does not care.

`handle_cancellation` and `settle_trade` both go through the same release, so a fully-filled order
and a cancelled one drain the entry identically.

### The key has to exist before R1 runs — CI caught that it did not

The map is keyed on `cmd.order_id`, and that field is assigned by the **journaling stage**
(`processors/src/journaling.rs:33`), not at ingress. On `develop`, journaling shares a disruptor
barrier with the four R1 handlers — `handle_events_with(journaling_handler)` at
`server/src/engine.rs:287`, with the first `and_then()` only at line 320, *after* R1. R1 therefore
often ran concurrently with journaling, observed `order_id == 0`, and filed the collateral under key
`0`. R2 later looked up the real snowflake id, missed, and stranded exactly the funds this PR set
out to recover:

```
WARN risk_engine: event="missing_bid_collateral" shard_id=2 order_id=3268419543565205504 user_id=42
assertion failed: All locked funds for taker should be settled or released
  left: 250125000   right: 0
```

This is a correction to the "Sharding holds" claim below, which was verified but not sufficient.
Shard *routing* was never the problem — R1 and R2 do land on the same engine instance. What was
never checked is *when* the key becomes valid, and it was not valid yet at R1. The failure
reproduced **2 runs in 10**, which is why a single local `cargo test --workspace` passed and the
review pass found nothing.

#158 is precisely the barrier that fixes this, so this branch is rebased onto it rather than
duplicating the change. Verified on the rebased branch: **0 failures in 15 consecutive runs** of
`test_ioc_market_order_partial_fill_and_cancel` (`server/src/lib.rs:844`).

**Verified rather than assumed:**

- **ASK is genuinely unaffected.** Base collateral is the raw `size` with no scaling function —
  placement locks `size`, each fill spends `event.size`, cancel unlocks the raw remainder. The three
  values are trivially additive, so ASK keeps its existing path and costs zero bytes.
- **Sharding holds.** R1 and R2 route through the same engine instance per shard via `user_id & 3`,
  so a given order's placement, fills and cancel are always handled by the shard that holds its
  entry. This remains true — it just was not the whole ordering story, per the section above.
- **Lock ordering is consistent** — `balances` then `bid_collateral`, at every site — so the new lock
  cannot invert against the existing one.

A cancel or settlement for an order the engine has no record of logs a `missing_bid_collateral`
warning and no-ops. No unwrap, no panic on missing state. That warning is what surfaced the race
above rather than a corrupt balance, and it is covered by
`test_bid_cancel_without_collateral_record_is_safe`.

## Cost

16 bytes of key and value per **live BID**, plus hash-table overhead, released when the order
completes or is cancelled. Nothing for ASK.

## Tests

At the **shipped ETH/USDT scale**, not unit scale — at unit scale `calculate_quote_cost` is the
identity and this defect is invisible, which is exactly why it survived. Covering: cancel with no
fill, partial fill then cancel, multiple partial fills then cancel, and full fill. Each asserts the
user's balance returns exactly to its starting value with nothing left locked.

`cargo test -p processors -p vex-server`: 28 passed, 0 failed. clippy: 0 warnings. On its own that
single green run is no longer sufficient evidence for this change — it was green while the R1
ordering race was live — hence the 15-run repetition of the IOC test recorded above.

## Related

Closes #169

- vex-core #127 / PR #158 — the journaling barrier this is stacked on. Without it `cmd.order_id` is
  still zero when R1 files the collateral.
- vex-core #135 / PR #170 — the shipped-scale test suite that found this. Its
  `#[ignore]`d `test_shipped_eth_bid_partial_fill_cancel_has_no_collateral_residue` can be
  un-ignored once this merges.
- vex-core #111 / PR #146, #119 / PR #154, #133 / PR #151 — single-rounding defects in the same
  arithmetic. This one is different: no single rounding is wrong, they just do not sum.
- vex-core #113 / PR #153 — settlement atomicity, touching the same balance mutations.
