### PR TITLE
docs(risk): state that market buys are capped, not swept, and pin it with a test

### DIFF
--- a/processors/src/risk_engine.rs
+++ b/processors/src/risk_engine.rs
@@ -467,6 +467,13 @@ impl RiskEngine {
         Ok(())
     }
 
+    /// Applies the R1 funding bound to market BUY orders.
+    ///
+    /// Market BUY orders are capped, not swept: the `u64::MAX` market sentinel is replaced with
+    /// `best_ask + floor(best_ask * slippage_bps / 10_000)`. The matching engine then uses that
+    /// effective price as a limit, so liquidity above the cap remains unfilled. The response keeps
+    /// the ordinary matching status (`PartiallyFilled` after any fill, otherwise `Cancelled` for
+    /// IOC) and returns the effective cap in `price`.
     #[inline]
     fn bid_amount(&self, cmd: &mut OrderCommand, price_cache: Arc<PriceCache>) -> Result<u64> {
         // Get spec early

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -1486,6 +1486,84 @@ mod tests {
     }
 
     #[test]
+    fn test_market_buy_stops_at_slippage_cap_with_liquidity_beyond_it() {
+        let mut specs = HashMap::new();
+        let base_asset_id = 1;
+        let quote_asset_id = 2;
+        let market_id = ((quote_asset_id as u32) << 16) | (base_asset_id as u32);
+        specs.insert(
+            market_id,
+            CoreMarketSpecification::builder()
+                .market_id(market_id)
+                .market_type(MarketType::Spot)
+                .maker_fee(10)
+                .taker_fee(20)
+                .slippage(500)
+                .build()
+                .unwrap(),
+        );
+
+        let (mut producer, risk_engines, rx) = setup_tuple(specs);
+        let maker_id = 101;
+        let taker_id = 42;
+        let maker_shard = 1;
+        let taker_shard = 2;
+
+        risk_engines[maker_shard].set_balance(maker_id, base_asset_id, UserBalance::new(30, 0));
+        risk_engines[taker_shard].set_balance(taker_id, quote_asset_id, UserBalance::new(3_150, 0));
+
+        for (client_order_id, price) in [(1, 100), (2, 110), (3, 120)] {
+            producer.publish(|cmd| {
+                *cmd = OrderCommand::place_order(
+                    TimeInForce::Gtc,
+                    maker_id,
+                    price,
+                    10,
+                    Side::Ask,
+                    market_id,
+                    client_order_id,
+                );
+            });
+            let response = rx.recv_timeout(Duration::from_secs(1)).unwrap();
+            assert_eq!(response.status, Status::Placed);
+        }
+
+        producer.publish(|cmd| {
+            *cmd = OrderCommand::place_order(
+                TimeInForce::Ioc,
+                taker_id,
+                u64::MAX,
+                30,
+                Side::Bid,
+                market_id,
+                4,
+            );
+        });
+        let response = rx.recv_timeout(Duration::from_secs(5)).unwrap();
+
+        assert_eq!(response.status, Status::PartiallyFilled);
+        assert_eq!(
+            response.price, 105,
+            "response must expose the effective cap"
+        );
+        assert_eq!(
+            response.size, 20,
+            "quantity above the cap must remain unfilled"
+        );
+
+        let fill = response.events().unwrap();
+        assert_eq!((fill.price, fill.size), (100, 10));
+        assert!(
+            fill.next_event.is_none(),
+            "levels above the cap must not trade"
+        );
+
+        let l2 = response.l2_data.as_ref().unwrap();
+        assert_eq!(l2.ask_prices, [110, 120]);
+        assert_eq!(l2.ask_volumes, [10, 10]);
+    }
+
+    #[test]
     fn test_fok_limit_order_rejection_and_success() {
         // 1. Setup
         let mut specs = HashMap::new();


### PR DESCRIPTION
> **This changes no behaviour.** It documents and pins the existing one. Read the "why not a sweep"
> section before approving — the alternative was rejected deliberately, not skipped.

## The problem

Risk R1 rewrites a market BUY's `u64::MAX` sentinel to `best_ask + floor(best_ask * slippage_bps /
10000)`. The matching engine then treats that as a limit price and stops there rather than sweeping
the book. With levels at 100 / 110 / 120 and a 5% cap, a market buy for 30 fills only the 10 at 100
and leaves 20 unfilled despite ample liquidity above — and the client is told `PartiallyFilled` with
no stated reason.

## What this PR does

Documents the behaviour at the point a reader meets it, and adds an end-to-end regression test
through the real pipeline against a three-level book, asserting: 10 filled at 100, 20 residual, and
`price` returned as the effective cap 105.

## Why not implement a real sweep

A true sweep needs a different collateral model. R1 locks quote up front, and you cannot lock a
bounded amount for an unbounded sweep — the whole point of the cap is that it makes the maximum quote
exposure computable before the order enters the book. Changing that is a design change to the money
model, not a fix, and it would have to be designed alongside #169 and #113.

The asymmetry with market SELL is deliberate for the same reason: a SELL locks a fixed base `size`,
so its exposure is already bounded and it keeps price 0 and sweeps the bids.

## Why not a distinct status

`Status` is `{Rejected, Placed, Cancelled, PartiallyFilled, Filled, Processing, Processed}`. None of
them means "stopped at the slippage bound". The SBE field is a `uint8` with values 7..254 unused, but
unused values decode as `NullVal` and are rejected — so adding one is a wire-format change across
both repositories, which is out of scope for this issue.

## The client can already distinguish the two cases

This is the part the issue asked for, and it turns out to be answerable today:

| Situation | Status | `price` in the response |
|---|---|---|
| No liquidity at all | `Rejected` | unchanged `u64::MAX` sentinel |
| Stopped at the slippage bound | `PartiallyFilled` (or `Cancelled` for IOC with no fill) | the **effective cap** |

So a finite `price` on a market order *is* the signal, and the gateway already forwards it — vex-gateway
PR #83 sets `order_price = response.price`. What was missing was anyone saying so. That is now in a
doc comment on the R1 path and pinned by the test.

`cargo test -p processors -p vex-server`: 23 passed, 0 failed. clippy: 0 warnings.

## Related

Closes #139

- vex-gateway #50 / PR #83 — surfaces `response.price` to the client, which is what makes the cap
  observable end to end.
- vex-core #169 / PR #171 and #113 / PR #153 — the collateral model any future sweep would have to be
  designed against.
- vex-core #112 / PR #150 — the sentinel prices this path exists to replace.
