### PR TITLE
fix(networking): stop handshakes blocking order ingress, and reap squatted gateway slots

### DIFF
--- a/networking/src/server/duologue.rs
+++ b/networking/src/server/duologue.rs
@@ -1,4 +1,5 @@
 use crate::server::cmd_handler::FragmentHandler;
+use crate::server::gateway_manager::GatewaySessionEvent;
 use common::OrderCommand;
 use disruptor::{MultiProducer, SingleConsumerBarrier};
 use rusteron_archive::{
@@ -99,6 +100,7 @@ impl Drop for Duologue {
 pub struct DuologueImageAvailable {
     pub expected_session_id: i32,
     pub gateway_id: u8,
+    pub tx: Sender<GatewaySessionEvent>,
 }
 
 impl AeronAvailableImageCallback for DuologueImageAvailable {
@@ -139,6 +141,17 @@ impl AeronAvailableImageCallback for DuologueImageAvailable {
                 session = format_args!("{:#x}", session_id),
                 address = %address
             );
+            if let Err(e) = self.tx.send(GatewaySessionEvent::ImageAvailable {
+                gateway_id: self.gateway_id,
+                session_id,
+            }) {
+                error!(
+                    target: "gateway_manager",
+                    action = "image_available_notification_failed",
+                    gateway_id = self.gateway_id,
+                    error = %e
+                );
+            }
         }
     }
 }
@@ -146,7 +159,7 @@ impl AeronAvailableImageCallback for DuologueImageAvailable {
 pub struct DuologueImageUnavailable {
     pub session_id: i32,
     pub gateway_id: u8,
-    pub tx: Sender<u8>,
+    pub tx: Sender<GatewaySessionEvent>,
 }
 
 impl AeronUnavailableImageCallback for DuologueImageUnavailable {
@@ -162,7 +175,10 @@ impl AeronUnavailableImageCallback for DuologueImageUnavailable {
             session = format_args!("{:#x}", self.session_id)
         );
 
-        if let Err(e) = self.tx.send(self.gateway_id) {
+        if let Err(e) = self.tx.send(GatewaySessionEvent::ImageUnavailable {
+            gateway_id: self.gateway_id,
+            session_id: self.session_id,
+        }) {
             error!(
                 target: "gateway_manager",
                 action = "core_publication_cleanup_request_failed",

--- a/networking/src/server/gateway_manager.rs
+++ b/networking/src/server/gateway_manager.rs
@@ -2,29 +2,47 @@ use crate::server::duologue::{
     DUOLOGUE_STREAM_ID, Duologue, DuologueImageAvailable, DuologueImageUnavailable,
 };
 use crate::server::gateway_publications::Publications;
-use crate::utils::{
-    PortAllocator, SessionAllocator, new_publication_with_mdc_and_session,
-    new_subscription_with_handlers_and_session, send_message, send_message_with_retries,
-};
+use crate::utils::{PortAllocator, SessionAllocator, send_message};
 use common::{MAX_GATEWAYS, OrderCommand};
 use disruptor::{MultiProducer, SingleConsumerBarrier};
-use rusteron_archive::{Aeron, AeronPublication, Handler};
+use rusteron_archive::{
+    Aeron, AeronAsyncAddPublication, AeronAsyncAddSubscription, AeronPublication,
+    AeronSubscription, Handler,
+};
+use std::cell::RefCell;
+use std::collections::VecDeque;
+use std::ffi::CString;
 use std::sync::mpsc::{Receiver, Sender, TryRecvError, channel};
 use std::sync::{Arc, RwLock};
+use std::time::{Duration, Instant};
 use tracing::{debug, error, info, warn};
 use vex_config::{CoreNetworkingConfig, GatewayAuthenticationKey};
 
 use super::ServerError;
+
+const HANDSHAKE_IDLE_TIMEOUT: Duration = Duration::from_secs(30);
+const HANDSHAKE_RATE_WINDOW: Duration = Duration::from_secs(1);
+// Match the global budget to the slot count so every gateway can handshake concurrently.
+const HANDSHAKE_RATE_LIMIT: usize = MAX_GATEWAYS;
+const ACCEPT_RETRY_INTERVAL: Duration = Duration::from_millis(100);
+const ACCEPT_RETRY_LIMIT: usize = 5;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum GatewaySlotState {
+    AwaitingImage { allocated_at: Instant },
+    Live,
+}
 
 pub struct Session {
     slots: [Option<GatewaySlot>; MAX_GATEWAYS],
 }
 
 pub struct GatewaySlot {
-    duologue: Duologue,
+    duologue: Option<Duologue>,
     port_data: u16,
     port_control: u16,
     session_id: i32,
+    state: GatewaySlotState,
 }
 
 impl Session {
@@ -37,25 +55,72 @@ impl Session {
     pub fn iter(&self) -> impl Iterator<Item = &Duologue> {
         self.slots
             .iter()
-            .filter_map(|s| s.as_ref().map(|slot| &slot.duologue))
+            .filter_map(|slot| slot.as_ref()?.duologue.as_ref())
     }
 
-    pub fn insert(&mut self, gateway_id: u8, session_id: i32, duologue: Duologue, ports: &[u16]) {
+    fn reserve(
+        &mut self,
+        gateway_id: u8,
+        session_id: i32,
+        ports: [u16; 2],
+        allocated_at: Instant,
+    ) -> bool {
         if (gateway_id as usize) >= MAX_GATEWAYS {
-            return;
+            return false;
         }
-        self.slots[gateway_id as usize] = Some(GatewaySlot {
-            duologue,
+        let slot = &mut self.slots[gateway_id as usize];
+        if slot.is_some() {
+            return false;
+        }
+        *slot = Some(GatewaySlot {
+            duologue: None,
             session_id,
             port_data: ports[0],
             port_control: ports[1],
+            state: GatewaySlotState::AwaitingImage { allocated_at },
         });
+        true
     }
 
-    pub fn remove(&mut self, gateway_id: u8) -> Option<Duologue> {
+    fn attach_duologue(
+        &mut self,
+        gateway_id: u8,
+        session_id: i32,
+        duologue: Duologue,
+    ) -> Result<(), Duologue> {
+        let Some(slot) = self
+            .slots
+            .get_mut(gateway_id as usize)
+            .and_then(Option::as_mut)
+        else {
+            return Err(duologue);
+        };
+        if slot.session_id != session_id || slot.duologue.is_some() {
+            return Err(duologue);
+        }
+        slot.duologue = Some(duologue);
+        Ok(())
+    }
+
+    fn mark_live(&mut self, gateway_id: u8, session_id: i32) -> bool {
+        let Some(slot) = self
+            .slots
+            .get_mut(gateway_id as usize)
+            .and_then(Option::as_mut)
+        else {
+            return false;
+        };
+        if slot.session_id != session_id {
+            return false;
+        }
+        slot.state = GatewaySlotState::Live;
+        true
+    }
+
+    fn remove(&mut self, gateway_id: u8) -> Option<GatewaySlot> {
         let gateway_id = gateway_id as usize;
         if gateway_id < MAX_GATEWAYS {
-            self.slots[gateway_id].take().map(|slot| slot.duologue)
+            self.slots[gateway_id].take()
         } else {
             None
         }
@@ -90,6 +155,88 @@ impl Session {
         }
         sessions
     }
+
+    fn gateway_ids(&self) -> Vec<u8> {
+        self.slots
+            .iter()
+            .enumerate()
+            .filter_map(|(gateway_id, slot)| slot.as_ref().map(|_| gateway_id as u8))
+            .collect()
+    }
+
+    fn expired_pending(&self, now: Instant) -> Vec<u8> {
+        self.slots
+            .iter()
+            .enumerate()
+            .filter_map(|(gateway_id, slot)| {
+                slot.as_ref()
+                    .filter(|slot| handshake_is_expired(slot.state, now))
+                    .map(|_| gateway_id as u8)
+            })
+            .collect()
+    }
+}
+
+fn handshake_is_expired(state: GatewaySlotState, now: Instant) -> bool {
+    match state {
+        GatewaySlotState::AwaitingImage { allocated_at } => {
+            now.saturating_duration_since(allocated_at) >= HANDSHAKE_IDLE_TIMEOUT
+        }
+        GatewaySlotState::Live => false,
+    }
+}
+
+struct HandshakeRateLimiter {
+    accepted: VecDeque<Instant>,
+}
+
+impl HandshakeRateLimiter {
+    fn new() -> Self {
+        Self {
+            accepted: VecDeque::with_capacity(HANDSHAKE_RATE_LIMIT),
+        }
+    }
+
+    fn allow(&mut self, now: Instant) -> bool {
+        while self.accepted.front().is_some_and(|accepted_at| {
+            now.saturating_duration_since(*accepted_at) >= HANDSHAKE_RATE_WINDOW
+        }) {
+            self.accepted.pop_front();
+        }
+        if self.accepted.len() >= HANDSHAKE_RATE_LIMIT {
+            return false;
+        }
+        self.accepted.push_back(now);
+        true
+    }
+}
+
+pub(super) enum GatewaySessionEvent {
+    ImageAvailable { gateway_id: u8, session_id: i32 },
+    ImageUnavailable { gateway_id: u8, session_id: i32 },
+}
+
+struct PendingHandshake {
+    gateway_id: u8,
+    handshake_session_id: i32,
+    dedicated_session_id: i32,
+    ports: [u16; 2],
+    encryption_key: i32,
+    response_publication: AeronPublication,
+    publication_registration: Option<AeronAsyncAddPublication>,
+    subscription_registration: Option<AeronAsyncAddSubscription>,
+    publication: Option<AeronPublication>,
+    subscription: Option<AeronSubscription>,
+    on_image_available_handler: Option<Handler<DuologueImageAvailable>>,
+    on_image_unavailable_handler: Option<Handler<DuologueImageUnavailable>>,
+    session_attached: bool,
+    accept_attempts: usize,
+    next_accept_attempt: Instant,
+}
+
+enum PendingHandshakeStatus {
+    Pending,
+    Complete,
 }
 
 /// Manages gateway connections and session lifecycle
@@ -103,7 +250,6 @@ pub struct GatewayManager {
     aeron: Aeron,
     /// Core configuration
     config: CoreNetworkingConfig,
-    /// Shared key expected in authenticated gateway handshakes
     authentication_key: GatewayAuthenticationKey,
     /// Port allocator for gateway sessions
     port_allocator: PortAllocator,
@@ -113,10 +259,14 @@ pub struct GatewayManager {
     producer: MultiProducer<OrderCommand, SingleConsumerBarrier>,
     /// Aeron publications for each gateway
     publications: Arc<Publications>,
-    /// Channel for receiving cleanup requests from image unavailable callbacks
-    cleanup_rx: Receiver<u8>,
+    /// Channel for receiving liveness changes from Aeron image callbacks
+    session_event_rx: Receiver<GatewaySessionEvent>,
     /// Channel sender cloned for each callback
-    cleanup_tx: Sender<u8>,
+    session_event_tx: Sender<GatewaySessionEvent>,
+    /// Non-blocking Aeron registrations and ACCEPT delivery state
+    pending_handshakes: RefCell<[Option<PendingHandshake>; MAX_GATEWAYS]>,
+    /// Bounds unauthenticated session allocation work
+    handshake_rate_limiter: RefCell<HandshakeRateLimiter>,
 }
 
 impl GatewayManager {
@@ -128,7 +278,7 @@ impl GatewayManager {
         producer: MultiProducer<OrderCommand, SingleConsumerBarrier>,
         publications: Arc<Publications>,
     ) -> Result<Self, ServerError> {
-        let (cleanup_tx, cleanup_rx) = channel();
+        let (session_event_tx, session_event_rx) = channel();
 
         Ok(Self {
             gateway_sessions: RwLock::new(Session::new()),
@@ -147,8 +297,10 @@ impl GatewayManager {
             authentication_key,
             producer,
             publications,
-            cleanup_rx,
-            cleanup_tx,
+            session_event_rx,
+            session_event_tx,
+            pending_handshakes: RefCell::new([(); MAX_GATEWAYS].map(|_| None)),
+            handshake_rate_limiter: RefCell::new(HandshakeRateLimiter::new()),
         })
     }
 
@@ -168,18 +320,41 @@ impl GatewayManager {
         }
     }
 
-    /// Processes pending cleanup requests from image unavailable callbacks
-    fn process_cleanup_requests(&self) {
+    /// Applies liveness changes reported by Aeron image callbacks.
+    fn process_session_events(&self) {
         loop {
-            match self.cleanup_rx.try_recv() {
-                Ok(gateway_id) => {
-                    debug!(
-                        target: "gateway_manager",
-                        action = "cleanup_process",
-                        gateway_id
-                    );
-                    if let Err(e) = self.remove_gateway_session(gateway_id) {
-                        // Log but don't fail - session might already be removed
+            match self.session_event_rx.try_recv() {
+                Ok(GatewaySessionEvent::ImageAvailable {
+                    gateway_id,
+                    session_id,
+                }) => {
+                    let marked_live = self
+                        .gateway_sessions
+                        .write()
+                        .unwrap()
+                        .mark_live(gateway_id, session_id);
+                    if !marked_live {
+                        warn!(
+                            target: "gateway_manager",
+                            action = "image_available_stale",
+                            gateway_id,
+                            session = format_args!("{:#x}", session_id)
+                        );
+                    }
+                }
+                Ok(GatewaySessionEvent::ImageUnavailable {
+                    gateway_id,
+                    session_id,
+                }) => {
+                    let session_matches = self
+                        .gateway_sessions
+                        .read()
+                        .unwrap()
+                        .slots
+                        .get(gateway_id as usize)
+                        .and_then(Option::as_ref)
+                        .is_some_and(|slot| slot.session_id == session_id);
+                    if session_matches && let Err(e) = self.remove_gateway_session(gateway_id) {
                         warn!(
                             target: "gateway_manager",
                             action = "cleanup_remove_failed",
@@ -192,7 +367,7 @@ impl GatewayManager {
                 Err(TryRecvError::Disconnected) => {
                     error!(
                         target: "gateway_manager",
-                        action = "cleanup_channel_disconnected"
+                        action = "session_event_channel_disconnected"
                     );
                     break;
                 }
@@ -262,10 +437,26 @@ impl GatewayManager {
             }
         };
 
+        // Authenticate before parsing the id, checking for duplicates, or allocating any
+        // resource, so an unauthenticated peer can never reach the allocator (PR #176).
         if self.authentication_is_enabled()
-            && let Err(e) = authenticate_gateway(&self.authentication_key, encryption_key)
+            && let Err(e) = self.authenticate_gateway(encryption_key)
         {
             return self.reject_handshake(publication, session_id, gateway_id_str, source, e);
+        }
+
+        // Rate-limit after authentication (PR #174), so an unauthenticated flood cannot
+        // consume the budget legitimate gateways need to reconnect.
+        let now = Instant::now();
+        if !self.handshake_rate_limiter.borrow_mut().allow(now) {
+            let unavailable_msg = format!(
+                "{session_id} {gateway_id_str} UNAVAILABLE {}",
+                HANDSHAKE_RATE_WINDOW.as_secs()
+            );
+            send_message(publication, unavailable_msg.as_bytes())?;
+            return Err(ServerError::CapacityExceededError(
+                "Handshake rate limit exceeded".to_string(),
+            ));
         }
 
         let gateway_id = {
@@ -302,55 +493,18 @@ impl GatewayManager {
             }
         };
 
-        self.check_duplicate_connection(publication, session_id, gateway_id, source)?;
+        self.check_duplicate_connection(publication, session_id, gateway_id)?;
 
-        let (dedicated_session, ports) = self.allocate_gateway_session(gateway_id)?;
-        let encrypted_session = encryption_key ^ dedicated_session;
-
-        // Wait for publication to be connected before sending ACCEPT message
-        // This avoids transient errors during connection establishment
-        let mut attempts = 0;
-        const MAX_CONNECTION_WAIT_ATTEMPTS: usize = 50; // 5 seconds max wait
-        while !publication.is_connected() && attempts < MAX_CONNECTION_WAIT_ATTEMPTS {
-            std::thread::sleep(std::time::Duration::from_millis(100));
-            attempts += 1;
-        }
-        if !publication.is_connected() {
-            self.remove_gateway_session(gateway_id)?;
-            return Err(ServerError::GatewayMessageError(
-                "Publication not connected after waiting".to_string(),
-            ));
-        }
-
-        // Send success response
-        let accept_msg = format!(
-            "{} gateway-{} ACCEPT {} {} {}",
-            session_id, gateway_id, ports[0], ports[1], encrypted_session
-        );
-        match send_message_with_retries(publication, accept_msg.as_bytes()) {
-            Ok(_) => (),
-            Err(e) => {
-                self.remove_gateway_session(gateway_id)?;
-                return Err(ServerError::GatewayMessageError(format!(
-                    "Failed to send ACCEPT message: {e}"
-                )));
-            }
-        }
-        info!(
-            target: "gateway_manager",
-            action = "gateway_connected",
-            gateway_id,
-            session = format_args!("{:#x}", dedicated_session),
-            data_port = ports[0],
-            control_port = ports[1]
-        );
+        self.allocate_gateway_session(gateway_id, session_id, encryption_key, publication, now)?;
 
         Ok(())
     }
 
     /// Polls all active gateway sessions
     pub fn poll(&self) -> Result<(), ServerError> {
-        self.process_cleanup_requests();
+        self.process_session_events();
+        self.process_pending_handshakes();
+        self.reap_idle_handshakes();
 
         // polls all active gateway sessions
         let guard = self.gateway_sessions.read().unwrap();
@@ -373,9 +527,7 @@ impl GatewayManager {
             .gateway_sessions
             .read()
             .expect("Gateway sessions lock poisoned during shutdown")
-            .iter()
-            .map(|duologue| duologue.gateway_id)
-            .collect();
+            .gateway_ids();
 
         for gateway_id in gateways_ids {
             self.remove_gateway_session(gateway_id)?;
@@ -386,132 +538,6 @@ impl GatewayManager {
             action = "shutdown_complete"
         );
         Ok(())
-    }
-
-    fn check_duplicate_connection(
-        &self,
-        publication: &AeronPublication,
-        session_id: i32,
-        gateway_id: u8,
-        source: &str,
-    ) -> Result<(), ServerError> {
-        // Check if gateway_id is within valid range (implicit capacity check)
-        if gateway_id as usize >= MAX_GATEWAYS {
-            return self.reject_handshake(
-                publication,
-                session_id,
-                &format!("gateway-{gateway_id}"),
-                source,
-                ServerError::GatewayMessageError(format!(
-                    "Gateway ID {} out of range (max: {})",
-                    gateway_id,
-                    MAX_GATEWAYS - 1
-                )),
-            );
-        }
-
-        // Check if this gateway is already connected
-        if self.is_gateway_connected(gateway_id) {
-            return self.reject_handshake(
-                publication,
-                session_id,
-                &format!("gateway-{gateway_id}"),
-                source,
-                ServerError::GatewayMessageError("Gateway already connected".to_string()),
-            );
-        }
-        Ok(())
-    }
-
-    /// Internal allocation method that creates a session with cleanup callback
-    /// Called during handshake to create session with image unavailable handling
-    fn allocate_gateway_session(&self, gateway_id: u8) -> Result<(i32, [u16; 2]), ServerError> {
-        // Get currently used ports and sessions from the Session struct
-        let mut guard = self.gateway_sessions.write().unwrap();
-        let ports_in_use = guard.get_ports_in_use();
-        let sessions_in_use = guard.get_sessions_in_use();
-        // drop(guard); // Release lock before allocating
-
-        // Allocate resources - now passing in the currently used values
-        let ports = match self.port_allocator.allocate(2, &ports_in_use) {
-            Ok(p) => p,
-            Err(e) => {
-                return Err(ServerError::ResourceAllocationError(e.to_string()));
-            }
-        };
-        let dedicated_session = match self.session_allocator.allocate(&sessions_in_use) {
-            Ok(s) => s,
-            Err(e) => {
-                return Err(ServerError::ResourceAllocationError(e.to_string()));
-            }
-        };
-
-        let publication = match new_publication_with_mdc_and_session(
-            &self.aeron,
-            &self.config.local_address,
-            ports[1],
-            DUOLOGUE_STREAM_ID,
-            dedicated_session,
-        ) {
-            Ok(publication) => publication,
-            Err(e) => {
-                return Err(ServerError::ResourceAllocationError(format!(
-                    "Failed to create publication: {e}"
-                )));
-            }
-        };
-
-        let on_image_available_handler = Handler::leak(DuologueImageAvailable {
-            expected_session_id: dedicated_session,
-            gateway_id,
-        });
-
-        let on_image_unavailable_handler = Handler::leak(DuologueImageUnavailable {
-            session_id: dedicated_session,
-            gateway_id,
-            tx: self.cleanup_tx.clone(),
-        });
-
-        let subscription = match new_subscription_with_handlers_and_session(
-            &self.aeron,
-            &self.config.local_address,
-            ports[0],
-            DUOLOGUE_STREAM_ID,
-            dedicated_session,
-            Some(&on_image_available_handler),
-            Some(&on_image_unavailable_handler),
-        ) {
-            Ok(subscription) => subscription,
-            Err(e) => {
-                return Err(ServerError::ResourceAllocationError(format!(
-                    "Failed to create subscription: {e}"
-                )));
-            }
-        };
-
-        // gateway session
-        let gateway_session = Duologue::new(
-            subscription,
-            on_image_available_handler,
-            on_image_unavailable_handler,
-            gateway_id,
-            self.producer.clone(),
-        );
-
-        self.publications.set(gateway_id, Arc::new(publication));
-
-        // Store session
-        guard.insert(gateway_id, dedicated_session, gateway_session, &ports);
-
-        debug!(
-            target: "gateway_manager",
-            action = "session_allocated",
-            gateway_id,
-            session = format_args!("{:#x}", dedicated_session),
-            data_port = ports[0],
-            control_port = ports[1]
-        );
-        Ok((dedicated_session, [ports[0], ports[1]]))
     }
 
     fn authentication_is_enabled(&self) -> bool {
@@ -538,24 +564,342 @@ impl GatewayManager {
         Err(error)
     }
 
-    /// Removes a gateway session and frees all associated resources
-    pub fn remove_gateway_session(&self, gateway_id: u8) -> Result<(), ServerError> {
-        // Get ports before removing the session
-        let ports_to_free = {
+    fn check_duplicate_connection(
+        &self,
+        publication: &AeronPublication,
+        session_id: i32,
+        gateway_id: u8,
+    ) -> Result<(), ServerError> {
+        // Check if gateway_id is within valid range (implicit capacity check)
+        if gateway_id as usize >= MAX_GATEWAYS {
+            let error_msg = format!(
+                "{session_id} gateway-{gateway_id} REJECT Invalid gateway ID (must be 0-{})",
+                MAX_GATEWAYS - 1
+            );
+            send_message(publication, error_msg.as_bytes())?;
+            return Err(ServerError::GatewayMessageError(format!(
+                "Gateway ID {} out of range (max: {})",
+                gateway_id,
+                MAX_GATEWAYS - 1
+            )));
+        }
+
+        // Check if this gateway is already connected
+        if self.is_gateway_connected(gateway_id) {
+            let error_msg =
+                format!("{session_id} gateway-{gateway_id} REJECT Gateway already connected");
+            send_message(publication, error_msg.as_bytes())?;
+            return Err(ServerError::GatewayMessageError(
+                "Gateway already connected".to_string(),
+            ));
+        }
+        Ok(())
+    }
+
+    /// Reserves a slot and submits non-blocking Aeron resource registrations.
+    fn allocate_gateway_session(
+        &self,
+        gateway_id: u8,
+        handshake_session_id: i32,
+        encryption_key: i32,
+        response_publication: &AeronPublication,
+        now: Instant,
+    ) -> Result<(), ServerError> {
+        let (ports_in_use, sessions_in_use) = {
             let guard = self.gateway_sessions.read().unwrap();
-            if let Some(slot) = guard
-                .slots
-                .get(gateway_id as usize)
-                .and_then(|s| s.as_ref())
-            {
-                vec![slot.port_data, slot.port_control]
-            } else {
-                vec![]
+            (guard.get_ports_in_use(), guard.get_sessions_in_use())
+        };
+        let allocated_ports = self
+            .port_allocator
+            .allocate(2, &ports_in_use)
+            .map_err(|e| ServerError::ResourceAllocationError(e.to_string()))?;
+        let ports = [allocated_ports[0], allocated_ports[1]];
+        let dedicated_session_id = self
+            .session_allocator
+            .allocate(&sessions_in_use)
+            .map_err(|e| ServerError::ResourceAllocationError(e.to_string()))?;
+
+        if !self.gateway_sessions.write().unwrap().reserve(
+            gateway_id,
+            dedicated_session_id,
+            ports,
+            now,
+        ) {
+            return Err(ServerError::GatewayMessageError(format!(
+                "Gateway gateway-{gateway_id} became occupied during allocation"
+            )));
+        }
+
+        let on_image_available_handler = Handler::leak(DuologueImageAvailable {
+            expected_session_id: dedicated_session_id,
+            gateway_id,
+            tx: self.session_event_tx.clone(),
+        });
+        let on_image_unavailable_handler = Handler::leak(DuologueImageUnavailable {
+            session_id: dedicated_session_id,
+            gateway_id,
+            tx: self.session_event_tx.clone(),
+        });
+
+        let publication_uri = CString::new(format!(
+            "aeron:udp?control={}:{}|control-mode=dynamic|session-id={dedicated_session_id}",
+            self.config.local_address, ports[1]
+        ))
+        .expect("controlled Aeron publication URI contains no NUL");
+        let subscription_uri = CString::new(format!(
+            "aeron:udp?endpoint={}:{}|session-id={dedicated_session_id}",
+            self.config.local_address, ports[0]
+        ))
+        .expect("controlled Aeron subscription URI contains no NUL");
+
+        let publication_registration = match self
+            .aeron
+            .async_add_publication(&publication_uri, DUOLOGUE_STREAM_ID)
+        {
+            Ok(registration) => registration,
+            Err(e) => {
+                self.remove_gateway_session(gateway_id)?;
+                return Err(ServerError::ResourceAllocationError(format!(
+                    "Failed to register publication: {e}"
+                )));
+            }
+        };
+        let subscription_registration = match self.aeron.async_add_subscription(
+            &subscription_uri,
+            DUOLOGUE_STREAM_ID,
+            Some(&on_image_available_handler),
+            Some(&on_image_unavailable_handler),
+        ) {
+            Ok(registration) => registration,
+            Err(e) => {
+                self.remove_gateway_session(gateway_id)?;
+                return Err(ServerError::ResourceAllocationError(format!(
+                    "Failed to register subscription: {e}"
+                )));
             }
         };
 
-        let mut session = match self.gateway_sessions.write().unwrap().remove(gateway_id) {
-            Some(duologue) => duologue,
+        self.pending_handshakes.borrow_mut()[gateway_id as usize] = Some(PendingHandshake {
+            gateway_id,
+            handshake_session_id,
+            dedicated_session_id,
+            ports,
+            encryption_key,
+            response_publication: response_publication.clone(),
+            publication_registration: Some(publication_registration),
+            subscription_registration: Some(subscription_registration),
+            publication: None,
+            subscription: None,
+            on_image_available_handler: Some(on_image_available_handler),
+            on_image_unavailable_handler: Some(on_image_unavailable_handler),
+            session_attached: false,
+            accept_attempts: 0,
+            next_accept_attempt: now,
+        });
+        Ok(())
+    }
+
+    fn process_pending_handshakes(&self) {
+        for gateway_id in 0..MAX_GATEWAYS {
+            let pending = self.pending_handshakes.borrow_mut()[gateway_id].take();
+            let Some(mut pending) = pending else {
+                continue;
+            };
+
+            match self.advance_pending_handshake(&mut pending, Instant::now()) {
+                Ok(PendingHandshakeStatus::Pending) => {
+                    self.pending_handshakes.borrow_mut()[gateway_id] = Some(pending);
+                }
+                Ok(PendingHandshakeStatus::Complete) => {}
+                Err(e) => {
+                    error!(
+                        target: "gateway_manager",
+                        action = "handshake_setup_failed",
+                        gateway_id = pending.gateway_id,
+                        error = %e
+                    );
+                    if let Err(remove_error) = self.remove_gateway_session(pending.gateway_id) {
+                        warn!(
+                            target: "gateway_manager",
+                            action = "failed_handshake_cleanup_failed",
+                            gateway_id = pending.gateway_id,
+                            error = %remove_error
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    fn advance_pending_handshake(
+        &self,
+        pending: &mut PendingHandshake,
+        now: Instant,
+    ) -> Result<PendingHandshakeStatus, ServerError> {
+        if !pending.session_attached {
+            if pending.publication.is_none() {
+                pending.publication = pending
+                    .publication_registration
+                    .as_ref()
+                    .expect("publication registration missing before attachment")
+                    .poll()
+                    .map_err(|e| {
+                        ServerError::ResourceAllocationError(format!(
+                            "Failed to create publication: {e}"
+                        ))
+                    })?;
+                if pending.publication.is_some() {
+                    pending.publication_registration = None;
+                }
+            }
+            if pending.subscription.is_none() {
+                pending.subscription = pending
+                    .subscription_registration
+                    .as_ref()
+                    .expect("subscription registration missing before attachment")
+                    .poll()
+                    .map_err(|e| {
+                        ServerError::ResourceAllocationError(format!(
+                            "Failed to create subscription: {e}"
+                        ))
+                    })?;
+                if pending.subscription.is_some() {
+                    pending.subscription_registration = None;
+                }
+            }
+
+            if pending.publication.is_none() || pending.subscription.is_none() {
+                return Ok(PendingHandshakeStatus::Pending);
+            }
+
+            let gateway_session = Duologue::new(
+                pending
+                    .subscription
+                    .take()
+                    .expect("checked dedicated subscription"),
+                pending
+                    .on_image_available_handler
+                    .take()
+                    .expect("image available handler missing"),
+                pending
+                    .on_image_unavailable_handler
+                    .take()
+                    .expect("image unavailable handler missing"),
+                pending.gateway_id,
+                self.producer.clone(),
+            );
+            let attach_result = {
+                self.gateway_sessions.write().unwrap().attach_duologue(
+                    pending.gateway_id,
+                    pending.dedicated_session_id,
+                    gateway_session,
+                )
+            };
+            if let Err(mut unattached_session) = attach_result {
+                if let Err(e) = unattached_session.close() {
+                    error!(
+                        target: "gateway_manager",
+                        action = "unattached_session_close_failed",
+                        gateway_id = pending.gateway_id,
+                        error = ?e
+                    );
+                }
+                return Err(ServerError::GatewayMessageError(format!(
+                    "Reserved slot for gateway-{} disappeared",
+                    pending.gateway_id
+                )));
+            }
+            self.publications.set(
+                pending.gateway_id,
+                Arc::new(
+                    pending
+                        .publication
+                        .take()
+                        .expect("checked dedicated publication"),
+                ),
+            );
+            pending.session_attached = true;
+
+            debug!(
+                target: "gateway_manager",
+                action = "session_allocated",
+                gateway_id = pending.gateway_id,
+                session = format_args!("{:#x}", pending.dedicated_session_id),
+                data_port = pending.ports[0],
+                control_port = pending.ports[1]
+            );
+        }
+
+        if !pending.response_publication.is_connected() || now < pending.next_accept_attempt {
+            return Ok(PendingHandshakeStatus::Pending);
+        }
+
+        let accept_msg = format!(
+            "{} gateway-{} ACCEPT {} {} {}",
+            pending.handshake_session_id,
+            pending.gateway_id,
+            pending.ports[0],
+            pending.ports[1],
+            pending.encryption_key ^ pending.dedicated_session_id
+        );
+        match send_message(&pending.response_publication, accept_msg.as_bytes()) {
+            Ok(()) => {
+                info!(
+                    target: "gateway_manager",
+                    action = "gateway_accepted",
+                    gateway_id = pending.gateway_id,
+                    session = format_args!("{:#x}", pending.dedicated_session_id),
+                    data_port = pending.ports[0],
+                    control_port = pending.ports[1]
+                );
+                Ok(PendingHandshakeStatus::Complete)
+            }
+            Err(e) => {
+                pending.accept_attempts += 1;
+                if pending.accept_attempts >= ACCEPT_RETRY_LIMIT {
+                    return Err(ServerError::GatewayMessageError(format!(
+                        "Failed to send ACCEPT message after {ACCEPT_RETRY_LIMIT} attempts: {e}"
+                    )));
+                }
+                pending.next_accept_attempt = now + ACCEPT_RETRY_INTERVAL;
+                Ok(PendingHandshakeStatus::Pending)
+            }
+        }
+    }
+
+    fn reap_idle_handshakes(&self) {
+        let now = Instant::now();
+        let expired = self.gateway_sessions.read().unwrap().expired_pending(now);
+        for gateway_id in expired {
+            warn!(
+                target: "gateway_manager",
+                action = "idle_handshake_reaped",
+                gateway_id,
+                idle_seconds = HANDSHAKE_IDLE_TIMEOUT.as_secs()
+            );
+            if let Err(e) = self.remove_gateway_session(gateway_id) {
+                warn!(
+                    target: "gateway_manager",
+                    action = "idle_handshake_cleanup_failed",
+                    gateway_id,
+                    error = %e
+                );
+            }
+        }
+    }
+
+    fn authenticate_gateway(&self, credentials: i32) -> Result<(), ServerError> {
+        authenticate_gateway(&self.authentication_key, credentials)
+    }
+
+    /// Removes a gateway session and frees all associated resources
+    pub fn remove_gateway_session(&self, gateway_id: u8) -> Result<(), ServerError> {
+        if (gateway_id as usize) < MAX_GATEWAYS {
+            self.pending_handshakes.borrow_mut()[gateway_id as usize] = None;
+        }
+
+        let slot = match self.gateway_sessions.write().unwrap().remove(gateway_id) {
+            Some(slot) => slot,
             None => {
                 return Err(ServerError::GatewayMessageError(format!(
                     "No active session for gateway-{gateway_id}"
@@ -567,7 +911,9 @@ impl GatewayManager {
         self.publications.remove(gateway_id);
 
         // close subscription
-        if let Err(e) = session.close() {
+        if let Some(mut session) = slot.duologue
+            && let Err(e) = session.close()
+        {
             error!(
                 target: "gateway_manager",
                 action = "session_close_failed",
@@ -578,16 +924,15 @@ impl GatewayManager {
 
         // Mark ports as recently freed to avoid OS-level port binding race conditions
         // The OS may still have the UDP port bound even after Aeron closes the subscription
-        if !ports_to_free.is_empty() {
-            self.port_allocator.mark_freed(&ports_to_free);
-            debug!(
-                target: "gateway_manager",
-                action = "ports_marked_freed",
-                gateway_id,
-                data_port = ports_to_free[0],
-                control_port = ports_to_free[1]
-            );
-        }
+        let ports_to_free = [slot.port_data, slot.port_control];
+        self.port_allocator.mark_freed(&ports_to_free);
+        debug!(
+            target: "gateway_manager",
+            action = "ports_marked_freed",
+            gateway_id,
+            data_port = ports_to_free[0],
+            control_port = ports_to_free[1]
+        );
 
         Ok(())
     }
@@ -623,6 +968,50 @@ fn authenticate_gateway(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn slot_reservation_rejects_duplicate_and_out_of_range_ids() {
+        let now = Instant::now();
+        let mut session = Session::new();
+
+        assert!(session.reserve(0, 101, [10_000, 10_001], now));
+        assert!(!session.reserve(0, 102, [10_002, 10_003], now));
+        assert!(!session.reserve(MAX_GATEWAYS as u8, 103, [10_004, 10_005], now));
+        assert_eq!(session.get_ports_in_use(), vec![10_000, 10_001]);
+        assert_eq!(session.get_sessions_in_use(), vec![101]);
+    }
+
+    #[test]
+    fn only_awaiting_image_slots_expire_at_idle_timeout() {
+        let allocated_at = Instant::now();
+        let awaiting = GatewaySlotState::AwaitingImage { allocated_at };
+
+        assert!(!handshake_is_expired(
+            awaiting,
+            allocated_at + HANDSHAKE_IDLE_TIMEOUT - Duration::from_nanos(1)
+        ));
+        assert!(handshake_is_expired(
+            awaiting,
+            allocated_at + HANDSHAKE_IDLE_TIMEOUT
+        ));
+        assert!(!handshake_is_expired(
+            GatewaySlotState::Live,
+            allocated_at + HANDSHAKE_IDLE_TIMEOUT + HANDSHAKE_IDLE_TIMEOUT
+        ));
+    }
+
+    #[test]
+    fn handshake_rate_limit_uses_a_rolling_window() {
+        let start = Instant::now();
+        let mut limiter = HandshakeRateLimiter::new();
+
+        for _ in 0..MAX_GATEWAYS {
+            assert!(limiter.allow(start));
+        }
+        assert!(!limiter.allow(start));
+        assert!(!limiter.allow(start + HANDSHAKE_RATE_WINDOW - Duration::from_nanos(1)));
+        assert!(limiter.allow(start + HANDSHAKE_RATE_WINDOW));
+    }
 
     #[test]
     fn correct_gateway_credential_is_accepted() {


### PR DESCRIPTION
## The problems

**Ingress stall.** `allocate_gateway_session` held the `gateway_sessions` **write** guard across port
allocation, Aeron publication *and* subscription creation, the publication-table update, slot
insertion and logging. Each Aeron creation could wait a second. `process_handshake_message` then
waited up to 5 s for the publication to connect plus 400 ms of `send_message_with_retries` — all
inline on the single thread that also polls every connected gateway's orders. **One handshake stalled
order ingress for the entire exchange.**

**Slot squatting.** No idle timeout and no reaping, so 16 HELLO packets permanently occupied every
gateway slot and the exchange became unreachable to legitimate gateways.

## The fix

**Nothing blocks the ingress thread any more.** Publication and subscription creation move to
`AeronAsyncAddPublication` / `AeronAsyncAddSubscription`, polled incrementally across ingress
iterations. ACCEPT delivery retries on a 100 ms interval driven by the same loop rather than by
`send_message_with_retries` sleeping in place. There is no `thread::sleep` and no timed wait left on
that path, and no new thread or async runtime was introduced to get there.

**The write guard now covers only the map mutation.** A slot is `reserve`d (map mutation, guard
released), Aeron setup proceeds outside the lock, and the `Duologue` is attached when it is ready.
`GatewaySlot::duologue` becomes `Option` to represent that interval honestly rather than leaving a
half-built slot visible.

**Handshakes have a state machine and a reaper.** A slot is `AwaitingImage { allocated_at }` until an
Aeron image actually appears, at which point it is `Live`. Only `AwaitingImage` slots expire, at
**30 s** — a live but quiet gateway is never reclaimed, because liveness comes from the image, not
from traffic. 30 s is chosen against the client: it permits a 20 s connection wait plus two 1 s
registrations, leaving 8 s of margin.

Liveness was previously only half-wired: `DuologueImageUnavailable` already requested slot cleanup
once a dedicated image had been established, but `GatewayImageUnavailableHandler` merely logged, and
nothing at all handled a session whose image **never** appeared. That is exactly the squatting case,
and it is what the reaper targets.

**Handshake allocations are rate-limited** on a rolling one-second window, so slots cannot be
re-squatted at line rate the moment the reaper frees them. The budget is `MAX_GATEWAYS` — 16, the
same constant that sizes the slot array.

**Correction: the first version of this PR set that budget to 4/second, and this description claimed
that was the fix. It was wrong, and the follow-up commit `f97a968` raises it to `MAX_GATEWAYS`.** The
limiter is a single *global* window, not per-gateway, so a fleet cold start in which more than four
gateways handshake in the same second gets the surplus refused — and a refusal is terminal, not a
back-off. The server replies `UNAVAILABLE <retry_after>`:

```rust
let unavailable_msg = format!(
    "{session_id} gateway-{gateway_id} UNAVAILABLE {}",
    HANDSHAKE_RATE_WINDOW.as_secs()
);
```

and the client's `perform_handshake` turns that straight into a terminal error and returns:

```rust
CoreResponse::Unavailable { retry_after_seconds } => Err(GatewayError::CoreError(format!(
    "Core unavailable, retry after {retry_after_seconds} seconds"
))),
```

Nothing in `vex-networking`'s client acts on `retry_after_seconds`; `start()` propagates the error and
the gateway never connects. The same ceiling made `cargo xtask test e2e --clients N` unusable for
N > 4 — the surplus clients were refused during startup and never came back.

`MAX_GATEWAYS` is the right number because it is the number the rest of the path is already built
for: `pending_handshakes` is a `[Option<PendingHandshake>; MAX_GATEWAYS]`, so it can already hold a
concurrent in-flight handshake for every gateway id. Every gateway connecting at once is a supported
state, not an attack signature.

## What this does not fix

**A determined attacker can still hold every slot.** 16 allocations/second against 16 slots with a
30 s timeout is far more than enough to keep them all occupied indefinitely — and so was 4, which is
why lowering the budget bought nothing worth the cold-start failures. This bounds resource growth and
lets slots recover once an attacker stops — it does not make the exchange available while one is
active.

The actual fix is **#114: the handshake performs no authentication at all**. Until a credential is
required, anything here is rate-shaping an unauthenticated endpoint. That is deliberately out of
scope: it needs a credential scheme agreed across both repositories.

## Tests

Synthetic-time unit tests for the pure logic — slot reservation rejecting duplicate and
out-of-range ids, only `AwaitingImage` slots expiring at the timeout, and the rolling-window rate
limiter. The Aeron interaction itself is not unit-testable without a live media driver.

The rate-limiter test now fills the window with `MAX_GATEWAYS` allocations rather than with
`HANDSHAKE_RATE_LIMIT` allocations. The original form was self-referential — it asserted the limiter
admits exactly `HANDSHAKE_RATE_LIMIT` requests, which passes for *any* value of that constant,
including 4. Anchoring it to the slot count is what makes it a test of the intended behaviour rather
than of the constant's own definition.

`cargo test -p vex-networking`: 6 passed, 0 failed. The follow-up adds no tests; it changes one
expectation, as described above.

CI clippy is red on this branch, on `networking/src/server/mod.rs:504`
(`useless_borrows_in_formatting`). That file is not touched by this PR and the lint reproduces on
`develop` — it is pre-existing, not a regression from these changes.

## Related

Closes #125

- vex-core #114 — the handshake requires no credential. That is the real fix for squatting; this
  is containment.
- vex-core #123 / PR #155 — the ingress thread rejecting rather than dropping when the ring is full.
  Both are about that thread staying responsive.
- vex-core #130 / PR #165 — container health, which cannot observe a stalled ingress thread.
