### PR TITLE
fix(replay): recover the journal correctly, or fail loudly instead of booting empty

### DIFF
--- a/networking/src/server/cmd_handler.rs
+++ b/networking/src/server/cmd_handler.rs
@@ -52,6 +52,8 @@ impl AeronFragmentHandlerCallback for FragmentHandler {
 pub struct ReplayFragmentHandler {
     pub gateway_id: u8,
     pub producer: MultiProducer<OrderCommand, SingleConsumerBarrier>,
+    pub commands_published: i64,
+    pub replay_error: Option<String>,
 }
 
 impl AeronFragmentHandlerCallback for ReplayFragmentHandler {
@@ -60,6 +62,7 @@ impl AeronFragmentHandlerCallback for ReplayFragmentHandler {
             let values = match header.get_values() {
                 Ok(values) => values,
                 Err(e) => {
+                    self.replay_error = Some(format!("failed to decode replay header: {e}"));
                     error!(
                         target: "replay_fragment",
                         gateway_id = self.gateway_id,
@@ -92,18 +95,15 @@ impl AeronFragmentHandlerCallback for ReplayFragmentHandler {
                     "processing replay order command"
                 );
 
-                if let Err(e) = self.producer.try_publish(|cmd| {
+                // Replay runs before live traffic is served, so blocking for ring-buffer capacity
+                // is safe and prevents recovery from silently dropping journal commands.
+                self.producer.publish(|cmd| {
                     *cmd = order_command.clone();
-                }) {
-                    error!(
-                        target: "replay_fragment",
-                        gateway_id = self.gateway_id,
-                        error = %e,
-                        "failed to publish replay order command to ring buffer"
-                    );
-                }
+                });
+                self.commands_published += 1;
             }
             Err(e) => {
+                self.replay_error = Some(format!("failed to decode replay order command: {e:?}"));
                 error!(
                     target: "replay_fragment",
                     gateway_id = self.gateway_id,

--- a/networking/src/server/mod.rs
+++ b/networking/src/server/mod.rs
@@ -39,11 +39,14 @@ use crate::server::gateway_handler::{
 };
 use crate::server::gateway_manager::GatewayManager;
 use crate::server::replay::{
-    ActiveRecordingReader, ExtendedRecordingDescriptor, RecorderDescriptorReader,
+    ExtendedRecordingDescriptor, RecorderDescriptorReader, RecordingCounter,
+    assert_replay_complete, assert_replay_position_complete, ensure_replayable_recording,
+    fail_on_replay_error, is_live_recording,
 };
 use crate::utils::{new_publication_with_mdc, new_subscription_with_handlers};
 use common::{FRAMESIZE, OrderCommand};
 use disruptor::{MultiProducer, SingleConsumerBarrier};
+use rusteron_archive::bindings::AERON_NULL_COUNTER_ID;
 use rusteron_archive::{
     Aeron, AeronArchiveAsyncConnect, AeronArchiveReplayParams, AeronAvailableImageLogger,
     AeronCError, AeronContext, AeronNotificationLogger, AeronSubscription,
@@ -71,6 +74,8 @@ pub const REPLAY_STREAM_ID: i32 = 2002;
 /// Channel for Aeron Recording also known as Aeron Control Channel
 const RECORDING_CHANNEL: &str = "aeron:ipc";
 const STARTUP_CONNECTION_TIMEOUT: Duration = Duration::from_secs(10);
+const LIVE_RECORDING_RELEASE_TIMEOUT: Duration = Duration::from_secs(10);
+const LIVE_RECORDING_RELEASE_POLL_INTERVAL: Duration = Duration::from_millis(100);
 
 /// Error types for VEX Core server operations
 #[derive(Error, Debug)]
@@ -91,6 +96,8 @@ pub enum ServerError {
     CapacityExceededError(String),
     #[error("Configuration error: {0}")]
     ConfigurationError(String),
+    #[error("Replay error: {0}")]
+    ReplayError(String),
     #[error("{0} did not connect within 10 seconds")]
     StartupConnectionTimeout(&'static str),
 }
@@ -323,20 +330,10 @@ impl VexCoreServer {
         self.image_available_handler.release();
         self.image_unavailable_handler.release();
         self.handshake_handler.release();
-        // Only stop recording subscription if we own it (subscription_id != Some(0))
-        // subscription_id = Some(0) means we're using an existing active recording we don't own
-        if let Some(sub_id) = self.subscription_id {
-            if sub_id != 0 {
-                if let Some(ref mut archive) = self.archive {
-                    archive.stop_recording_subscription(sub_id)?;
-                }
-            } else {
-                info!(
-                    target: "core_server",
-                    action = "skipping_stop_recording",
-                    "Using existing active recording, not stopping it"
-                );
-            }
+        if let Some(sub_id) = self.subscription_id
+            && let Some(ref mut archive) = self.archive
+        {
+            archive.stop_recording_subscription(sub_id)?;
         }
         if let Some(ref mut archive) = self.archive {
             archive.close()?;
@@ -420,74 +417,56 @@ impl VexCoreServer {
                 channel,
             )),
             None => {
-                // Check for existing active recordings before starting a new one
-                let mut active_reader = Handler::leak(ActiveRecordingReader::new());
-                let _ = archive.list_recordings_for_uri(
-                    0,
-                    i32::MAX,
+                info!(
+                    target: "recording",
+                    action = "starting_new_recording"
+                );
+                let subscription_id = archive.start_recording(
                     &RECORDING_CHANNEL.into_c_string(),
                     RECORDING_STREAM_ID,
-                    Some(&active_reader),
+                    SourceLocation::AERON_ARCHIVE_SOURCE_LOCATION_LOCAL,
+                    false,
                 )?;
-
-                if let Some(active_record) = &active_reader.active_recording {
-                    info!(
-                        target: "recording",
-                        action = "found_active_recording",
-                        recording_id = active_record.recording_id,
-                        start_position = active_record.start_position
-                    );
-                    // For active recordings, we can't extend them, but we can get the subscription_id
-                    // by querying the archive. Since the recording is already active, we return
-                    // a dummy subscription_id (0) and the channel. The publication will connect to
-                    // the existing recording.
-                    active_reader.release();
-                    Ok((0, RECORDING_CHANNEL.to_string()))
-                } else {
-                    active_reader.release();
-                    info!(
-                        target: "recording",
-                        action = "starting_new_recording"
-                    );
-                    // Try to start recording, and if it fails with "recording exists",
-                    // find the last recording and extend it
-                    match archive.start_recording(
-                        &RECORDING_CHANNEL.into_c_string(),
-                        RECORDING_STREAM_ID,
-                        SourceLocation::AERON_ARCHIVE_SOURCE_LOCATION_LOCAL,
-                        false,
-                    ) {
-                        Ok(subscription_id) => Ok((subscription_id, RECORDING_CHANNEL.to_string())),
-                        Err(e) => {
-                            // Check if error is "recording exists"
-                            let error_msg = format!("{}", e);
-                            if error_msg.contains("recording exists") {
-                                info!(
-                                    target: "recording",
-                                    action = "recording_exists_fallback",
-                                    error = %error_msg,
-                                    "Archive reports recording exists, treating as active recording"
-                                );
-
-                                // When Archive says "recording exists", it means there's an active recording
-                                // that we can't query via list_recordings_for_uri. We'll proceed with
-                                // the assumption that an active recording exists and use it.
-                                // Return subscription_id = 0 to indicate we're using an existing active recording.
-                                // The publication will connect to the existing recording automatically.
-                                info!(
-                                    target: "recording",
-                                    action = "using_existing_active_recording",
-                                    "Proceeding with existing active recording"
-                                );
-                                Ok((0, RECORDING_CHANNEL.to_string()))
-                            } else {
-                                // Some other error, return it
-                                Err(ServerError::AeronConnectionError(e))
-                            }
-                        }
-                    }
-                }
+                Ok((subscription_id, RECORDING_CHANNEL.to_string()))
             }
+        }
+    }
+
+    fn wait_for_recording_stop(
+        archive: &AeronArchive,
+        recording_id: i64,
+    ) -> Result<i64, ServerError> {
+        let deadline = Instant::now() + LIVE_RECORDING_RELEASE_TIMEOUT;
+        loop {
+            let mut descriptor_count = 0;
+            let mut stop_position = None;
+            archive.list_recordings_for_uri_once(
+                &mut descriptor_count,
+                recording_id,
+                1,
+                &RECORDING_CHANNEL.into_c_string(),
+                RECORDING_STREAM_ID,
+                |descriptor| {
+                    if descriptor.recording_id == recording_id {
+                        stop_position = Some(descriptor.stop_position);
+                    }
+                },
+            )?;
+
+            if let Some(stop_position) = stop_position
+                && !is_live_recording(stop_position)
+            {
+                return Ok(stop_position);
+            }
+
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                return Err(ServerError::ReplayError(format!(
+                    "live recording {recording_id} was not released within {} seconds",
+                    LIVE_RECORDING_RELEASE_TIMEOUT.as_secs()
+                )));
+            }
+            std::thread::sleep(remaining.min(LIVE_RECORDING_RELEASE_POLL_INTERVAL));
         }
     }
 
@@ -500,7 +479,11 @@ impl VexCoreServer {
         shutdown: Arc<AtomicBool>,
     ) -> Result<Option<ExtendedRecordingDescriptor>, ServerError> {
         let mut reader = Handler::leak(RecorderDescriptorReader::new());
-        let last_recording_id = archive.list_recordings_for_uri(
+        let mut recording_counter = Handler::leak(RecordingCounter);
+        let archive_recording_count =
+            archive.list_recordings(0, i32::MAX, Some(&recording_counter))?;
+        recording_counter.release();
+        let matching_recording_count = archive.list_recordings_for_uri(
             0,
             i32::MAX,
             &RECORDING_CHANNEL.into_c_string(), // aeron control request channel
@@ -510,24 +493,54 @@ impl VexCoreServer {
         info!(
             target: "replay",
             action = "recordings_listed",
-            recording_id = last_recording_id
+            archive_recording_count,
+            matching_recording_count,
+            skipped_empty = reader.skipped_empty,
+            skipped_invalid = reader.skipped_invalid
         );
+        ensure_replayable_recording(reader.skipped_invalid)?;
         if let Some(record) = &reader.last_recording {
             let session_id = record.session_id;
             let recording_id = record.recording_id;
+            let stop_position = if is_live_recording(record.stop_position) {
+                info!(
+                    target: "replay",
+                    action = "waiting_for_recording_release",
+                    recording_id
+                );
+                Self::wait_for_recording_stop(archive, recording_id)?
+            } else {
+                record.stop_position
+            };
+            if stop_position < record.start_position {
+                return Err(ServerError::ReplayError(format!(
+                    "recording {recording_id} has invalid positions: start {}, stop {stop_position}",
+                    record.start_position
+                )));
+            }
             info!(
                 target: "replay",
                 action = "recording_selected",
                 recording_id,
                 session_id,
                 start_position = record.start_position,
-                stop_position = record.stop_position
+                stop_position,
+                was_live = is_live_recording(record.stop_position)
             );
+            if stop_position == record.start_position {
+                info!(
+                    target: "replay",
+                    action = "empty_recording_skipped",
+                    recording_id
+                );
+                reader.release();
+                return Ok(None);
+            }
             let params = AeronArchiveReplayParams::new(
-                0,
+                AERON_NULL_COUNTER_ID,
                 i32::MAX,
                 record.start_position,
-                record.stop_position - record.start_position,
+                stop_position - record.start_position,
                 0,
                 0,
             )?;
@@ -556,6 +569,8 @@ impl VexCoreServer {
             let mut message_handler = Handler::leak(ReplayFragmentHandler {
                 producer,
                 gateway_id: 0,
+                commands_published: 0,
+                replay_error: None,
             });
             let subscription = aeron.add_subscription(
                 &replay_channel_with_session.into_c_string(),
@@ -575,12 +590,15 @@ impl VexCoreServer {
                 }
 
                 // Check position condition
-                if position >= record.stop_position {
+                if position >= stop_position {
                     break;
                 }
 
                 // Poll subscription and handle Result
+                let commands_published_before_poll = message_handler.commands_published;
                 let fragments_read = subscription.poll(Some(&message_handler), 1)?;
+
+                fail_on_replay_error(message_handler.replay_error.as_deref())?;
 
                 // If zero fragments, run idle strategy and continue
                 if fragments_read == 0 {
@@ -588,14 +606,18 @@ impl VexCoreServer {
                     continue;
                 }
 
-                // Otherwise, increment position by the number of fragments processed
-                position += fragments_read as i64 * FRAMESIZE;
+                // The handler blocks until publication succeeds; only published commands advance.
+                let commands_published =
+                    message_handler.commands_published - commands_published_before_poll;
+                assert_replay_complete(i64::from(fragments_read), commands_published)?;
+                position += commands_published * FRAMESIZE;
                 debug!(
                     target: "replay",
                     action = "position_advanced",
                     position
                 );
             }
+            assert_replay_position_complete(position, stop_position)?;
             info!(
                 target: "replay",
                 action = "completed",
@@ -604,7 +626,7 @@ impl VexCoreServer {
             );
             let extended_recording_descriptor = ExtendedRecordingDescriptor::new(
                 record.initial_term_id,
-                record.stop_position,
+                stop_position,
                 record.term_buffer_length,
                 recording_id,
             )?;

--- a/networking/src/server/replay.rs
+++ b/networking/src/server/replay.rs
@@ -1,3 +1,4 @@
+use rusteron_archive::bindings::AERON_NULL_POSITION;
 use rusteron_archive::{
     AeronArchiveRecordingDescriptor, AeronArchiveRecordingDescriptorConsumerFuncCallback,
     AeronUriStringBuilder, IntoCString,
@@ -54,14 +55,77 @@ pub struct RecordingInfo {
 #[derive(Debug)]
 pub struct RecorderDescriptorReader {
     pub last_recording: Option<RecordingInfo>,
+    pub skipped_empty: usize,
+    pub skipped_invalid: usize,
+}
+
+#[derive(Debug)]
+pub struct RecordingCounter;
+
+impl AeronArchiveRecordingDescriptorConsumerFuncCallback for RecordingCounter {
+    fn handle_aeron_archive_recording_descriptor_consumer_func(
+        &mut self,
+        _recording_descriptor: AeronArchiveRecordingDescriptor,
+    ) {
+    }
 }
 
 impl RecorderDescriptorReader {
     pub fn new() -> Self {
         Self {
             last_recording: None,
+            skipped_empty: 0,
+            skipped_invalid: 0,
         }
     }
+}
+
+pub fn is_live_recording(stop_position: i64) -> bool {
+    stop_position == i64::from(AERON_NULL_POSITION)
+}
+
+fn is_replayable_recording(start_position: i64, stop_position: i64) -> bool {
+    is_live_recording(stop_position) || (stop_position > 0 && start_position < stop_position)
+}
+
+pub fn ensure_replayable_recording(skipped_invalid: usize) -> Result<(), ServerError> {
+    if skipped_invalid > 0 {
+        return Err(ServerError::ReplayError(format!(
+            "archive contains {skipped_invalid} recording(s) with invalid positions"
+        )));
+    }
+    Ok(())
+}
+
+pub fn assert_replay_complete(
+    recorded_command_count: i64,
+    consumed_command_count: i64,
+) -> Result<(), ServerError> {
+    if recorded_command_count != consumed_command_count {
+        return Err(ServerError::ReplayError(format!(
+            "replay incomplete: recorded {recorded_command_count} command(s), consumed {consumed_command_count}"
+        )));
+    }
+    Ok(())
+}
+
+pub fn assert_replay_position_complete(
+    consumed_position: i64,
+    stop_position: i64,
+) -> Result<(), ServerError> {
+    if consumed_position < stop_position {
+        return Err(ServerError::ReplayError(format!(
+            "replay incomplete: consumed position {consumed_position}, stop position {stop_position}"
+        )));
+    }
+    Ok(())
+}
+
+pub fn fail_on_replay_error(replay_error: Option<&str>) -> Result<(), ServerError> {
+    if let Some(replay_error) = replay_error {
+        return Err(ServerError::ReplayError(replay_error.to_string()));
+    }
+    Ok(())
 }
 
 impl AeronArchiveRecordingDescriptorConsumerFuncCallback for RecorderDescriptorReader {
@@ -69,9 +133,10 @@ impl AeronArchiveRecordingDescriptorConsumerFuncCallback for RecorderDescriptorR
         &mut self,
         recording_descriptor: AeronArchiveRecordingDescriptor,
     ) {
-        if recording_descriptor.stop_position > 0
-            && recording_descriptor.start_position < recording_descriptor.stop_position
-        {
+        if is_replayable_recording(
+            recording_descriptor.start_position,
+            recording_descriptor.stop_position,
+        ) {
             debug!(
                 target: "replay",
                 action = "recording_found",
@@ -101,6 +166,11 @@ impl AeronArchiveRecordingDescriptorConsumerFuncCallback for RecorderDescriptorR
             };
             self.last_recording = Some(recording_info);
         } else {
+            if recording_descriptor.start_position == recording_descriptor.stop_position {
+                self.skipped_empty += 1;
+            } else {
+                self.skipped_invalid += 1;
+            }
             debug!(
                 target: "replay",
                 action = "recording_skipped",
@@ -112,55 +182,84 @@ impl AeronArchiveRecordingDescriptorConsumerFuncCallback for RecorderDescriptorR
     }
 }
 
-/// Reader that captures active recordings (where stop_position == 0)
-#[derive(Debug)]
-pub struct ActiveRecordingReader {
-    pub active_recording: Option<RecordingInfo>,
-}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use common::FRAMESIZE;
 
-impl ActiveRecordingReader {
-    pub fn new() -> Self {
-        Self {
-            active_recording: None,
-        }
+    #[test]
+    fn null_stop_position_is_live() {
+        assert!(is_live_recording(i64::from(AERON_NULL_POSITION)));
+        assert!(!is_live_recording(0));
+        assert!(!is_live_recording(1));
     }
-}
 
-impl AeronArchiveRecordingDescriptorConsumerFuncCallback for ActiveRecordingReader {
-    fn handle_aeron_archive_recording_descriptor_consumer_func(
-        &mut self,
-        recording_descriptor: AeronArchiveRecordingDescriptor,
-    ) {
-        // Active recordings have stop_position == 0
-        if recording_descriptor.stop_position == 0 {
-            debug!(
-                target: "recording",
-                action = "active_recording_found",
-                recording_id = recording_descriptor.recording_id,
-                start_position = recording_descriptor.start_position,
-                stop_position = recording_descriptor.stop_position
-            );
-            // Performing a deep copy here is essential;
-            // the descriptor lifetime ends after the callback.
-            let recording_info = RecordingInfo {
-                control_session_id: recording_descriptor.control_session_id,
-                correlation_id: recording_descriptor.correlation_id,
-                recording_id: recording_descriptor.recording_id,
-                start_timestamp: recording_descriptor.start_timestamp,
-                stop_timestamp: recording_descriptor.stop_timestamp,
-                start_position: recording_descriptor.start_position,
-                stop_position: recording_descriptor.stop_position,
-                initial_term_id: recording_descriptor.initial_term_id,
-                segment_file_length: recording_descriptor.segment_file_length,
-                term_buffer_length: recording_descriptor.term_buffer_length,
-                mtu_length: recording_descriptor.mtu_length,
-                session_id: recording_descriptor.session_id,
-                stream_id: recording_descriptor.stream_id,
-                stripped_channel_length: recording_descriptor.stripped_channel_length,
-                original_channel_length: recording_descriptor.original_channel_length,
-                source_identity_length: recording_descriptor.source_identity_length,
-            };
-            self.active_recording = Some(recording_info);
-        }
+    #[test]
+    fn live_and_non_empty_stopped_recordings_are_replayable() {
+        assert!(is_replayable_recording(0, i64::from(AERON_NULL_POSITION)));
+        assert!(is_replayable_recording(0, 96));
+        assert!(!is_replayable_recording(0, 0));
+        assert!(!is_replayable_recording(96, 96));
+    }
+
+    #[test]
+    fn replay_completion_requires_every_recorded_command() {
+        assert!(assert_replay_complete(2, 2).is_ok());
+        assert!(assert_replay_complete(2, 1).is_err());
+        assert!(assert_replay_complete(1, 2).is_err());
+    }
+
+    #[test]
+    fn replay_position_must_reach_stop_position_even_with_padding() {
+        let stop_position = FRAMESIZE * 2;
+        assert!(assert_replay_position_complete(stop_position, stop_position).is_ok());
+        assert!(assert_replay_position_complete(stop_position - 1, stop_position).is_err());
+
+        let padded_stop_position = stop_position + 1;
+        assert_ne!(padded_stop_position % FRAMESIZE, 0);
+        assert!(
+            assert_replay_position_complete(padded_stop_position, padded_stop_position).is_ok()
+        );
+    }
+
+    #[test]
+    fn recorded_decode_error_aborts_replay() {
+        let message = "failed to decode replay order command";
+        let result = fail_on_replay_error(Some(message));
+
+        assert!(matches!(
+            result,
+            Err(ServerError::ReplayError(replay_error)) if replay_error == message
+        ));
+    }
+
+    #[test]
+    fn empty_archive_is_allowed() {
+        assert!(ensure_replayable_recording(0).is_ok());
+    }
+
+    #[test]
+    fn archive_with_only_empty_recordings_is_allowed() {
+        let reader = RecorderDescriptorReader {
+            last_recording: None,
+            skipped_empty: 2,
+            skipped_invalid: 0,
+        };
+
+        assert!(reader.last_recording.is_none());
+        assert_eq!(reader.skipped_empty, 2);
+        assert_eq!(reader.skipped_invalid, 0);
+        assert!(ensure_replayable_recording(reader.skipped_invalid).is_ok());
+    }
+
+    #[test]
+    fn corrupt_recording_is_fatal() {
+        assert!(!is_replayable_recording(96, 95));
+        assert!(ensure_replayable_recording(1).is_err());
+    }
+
+    #[test]
+    fn live_descriptor_requires_release_before_replay() {
+        assert!(is_live_recording(i64::from(AERON_NULL_POSITION)));
     }
 }


### PR DESCRIPTION
## The problem

Four independent defects, any one of which breaks recovery.

**(a) Live recordings were skipped.** `ActiveRecordingReader` tested `stop_position == 0`, but Aeron
writes `NULL_POSITION = -1` for a live recording — that branch was dead code. `RecorderDescriptorReader`
required `stop_position > 0` and so also skipped a recording left live by a crash, which is exactly
the recovery case. `start_replay` then logged `no_recording_available` at **info** and returned
`Ok(None)`: the exchange booted with an empty book and zero balances, reporting success.

**(b) The replay was bounded by the wrong counter.** `AeronArchiveReplayParams::new`'s first argument
is `bounding_limit_counter_id` and the code passed `0`. Counter id 0 in the C media driver is
`AERON_SYSTEM_COUNTER_BYTES_SENT`, so recovery was bounded by total UDP bytes sent since driver
start.

**(c) A fallback that matched an error string.** The `"recording exists"` path returned a dummy
`subscription_id = 0` with a bare `aeron:ipc` channel and no term positioning, so a new recording was
opened instead of the old one extended — and `shutdown()` then deliberately never stopped it.

**(d) The replay pump dropped commands silently.** `try_publish` on a full ring, with the position
advancing anyway, so recovery could skip journal entries and report success.

## The fix

- `is_live_recording` tests against the binding's `AERON_NULL_POSITION`, and a live recording is
  waited out rather than replayed while live — see below.
- `bounding_limit_counter_id` is `AERON_NULL_COUNTER_ID` — the binding's own unbounded sentinel, not
  a literal.
- The string-matched fallback is deleted; the real error propagates.
- The pump uses blocking `publish`. Replay runs at startup before any traffic is served, so blocking
  for ring capacity is safe there — unlike the live ingress path — and there is a comment saying so.

**A live recording is waited out, not replayed.** The first version of this PR replayed a live
recording up to `get_max_recorded_position` and then handed the descriptor to `start_recording`,
which calls `extend_recording` — and Aeron will not extend a recording that is still active. The
whole journal was replayed only to be rejected at the very last step. The liveness check now runs
**before** `start_replay`: `wait_for_recording_stop` re-reads the descriptor every 100ms until
`stop_position` is no longer `NULL_POSITION`, for at most 10s, then fails with
`live recording {id} was not released within 10 seconds`. The recording is never stopped from here —
a still-live recording may belong to another instance that is running right now, and stopping it
would cut that instance's journal short. Waiting, and then giving up, is the only safe option.
`get_max_recorded_position` is no longer called anywhere.

**An empty journal is not a corrupt one.** The first version of this PR got this wrong as well: it
treated every skipped recording as evidence of corruption, so an instance restarting cleanly after
having recorded nothing (`start_position == stop_position`) refused to boot with
`archive contains 1 recording(s), but none are replayable`. `stop == start` is an empty journal and
is a legitimate state; `stop < start` is corrupt. The two are now counted apart —
`RecorderDescriptorReader` tracks `skipped_empty` and `skipped_invalid`, both logged on
`recordings_listed`, and `ensure_replayable_recording` takes `skipped_invalid` alone and fails only
on that. The selected recording gets the same treatment after the release wait:
`stop_position == start_position` logs `empty_recording_skipped` and returns `Ok(None)`, while
`stop_position < start_position` is an error naming the recording and both positions.

**Recovery otherwise fails loudly instead of booting empty:**

- an archive holding a recording with invalid positions is an error, not an `info` log;
- an empty archive — and an archive whose recordings are all empty — is still a legitimate first
  start and succeeds;
- a decode failure aborts immediately with the recorded message, rather than leaving the loop to spin
  without advancing;
- replay is complete only when the consumed **position reaches the recording's stop position**.

That last point came out of review and matters. The first attempt asserted on a command count derived
as `(stop_position - start_position) / FRAMESIZE`. Aeron inserts padding frames at term boundaries
which consume position but are never delivered to the fragment handler, so on any recording that
crossed a term boundary that count exceeds the number of commands actually replayed — and the check
would have refused to start after a **successful** recovery. A check that fires on correct behaviour
is worse than no check. Position-reached is true regardless of padding. The per-poll check still
compares handler-delivered fragments against published commands, where both sides are genuine counts.

Nine unit tests, still including the padding case — a byte range that is not an exact multiple of
`FRAMESIZE` must still pass. The empty-journal correction **changed an existing test expectation**:
`empty_archive_is_allowed_but_non_empty_archive_without_replay_is_not` asserted
`ensure_replayable_recording(1, false).is_err()`, which is precisely the rule that refused to boot on
an empty journal. That test is gone, replaced by `empty_archive_is_allowed`,
`archive_with_only_empty_recordings_is_allowed`, `corrupt_recording_is_fatal` and
`live_descriptor_requires_release_before_replay`; `ensure_replayable_recording` changed signature
with it.

CI `Build and Test` on `5ac2a43`: `vex-networking` lib 12 passed, `vex-server` lib 7 passed, 0
failed. Two jobs are red and neither comes from this branch — clippy on
`useless_borrows_in_formatting` at `networking/src/server/mod.rs:517`
(`format!("{}?session-id={}", &RECORDING_CHANNEL, replay_session_id)`, untouched here), and the
end-to-end job on `no associated function or constant named new_with_no_credentials_supplier found
for struct AeronArchiveContext`. Both fail identically on `develop` at `2852560`.

## Scope

`FRAMESIZE`-based position advancement is unchanged — that is #81, and this deliberately does not
touch it.

## Related

Closes #131, closes #132

- vex-core #81 — constant frame size and position accounting.
- vex-core #116 / PR #159 — archive write durability. Replay can only be as good as what was written.
- vex-core #127 / PR #158 — journaling ordering, without which the archive content is
  non-deterministic.
