### PR TITLE
perf: remove quadratic event appends, per-order allocations and hot-path logging

### DIFF
--- a/common/src/cmd.rs
+++ b/common/src/cmd.rs
@@ -9,6 +9,8 @@ use sbe_order::{ReadBuf, SBE_SCHEMA_ID, SbeResult, WriteBuf};
 use serde::de::Error;
 use serde::de::value::Error as SerdeError;
 use serde::{Deserialize, Serialize};
+use std::fmt;
+use std::ops::{Deref, DerefMut};
 
 // Size of the serialized OrderCommand in bytes
 // Header: 8 bytes
@@ -81,7 +83,7 @@ pub struct OrderCommand {
     pub status: Status,
 
     /// Passive order linked list
-    pub events: Option<Box<MatcherTradeEvent>>,
+    pub events: Option<MatcherTradeEventChain>,
 
     /// Final balance of the user/maker after this trade
     /// For Deposit/Withdraw commands, only balance[0] is used to represent the asset balance change
@@ -248,7 +250,7 @@ impl OrderCommand {
     }
 
     pub fn events_mut(&mut self) -> Option<&mut MatcherTradeEvent> {
-        self.events.as_mut().map(|e| e.as_mut())
+        self.events.as_deref_mut()
     }
 
     pub fn set_size(&mut self, size: u64) {
@@ -268,13 +270,10 @@ impl OrderCommand {
     }
 
     pub fn attach_event(&mut self, event: Box<MatcherTradeEvent>) {
-        if let Some(mut tail) = self.events.as_mut() {
-            while tail.next_event.is_some() {
-                tail = tail.next_event.as_mut().unwrap();
-            }
-            tail.next_event = Some(event);
+        if let Some(events) = self.events.as_mut() {
+            events.push(event);
         } else {
-            self.events = Some(event);
+            self.events = Some(MatcherTradeEventChain::new(event));
         }
     }
 
@@ -356,6 +355,75 @@ impl Drop for MatcherTradeEvent {
         while let Some(mut event) = next {
             next = event.next_event.take();
         }
+    }
+}
+
+pub struct MatcherTradeEventChain {
+    head: Box<MatcherTradeEvent>,
+    tail: usize,
+}
+
+impl MatcherTradeEventChain {
+    fn new(mut event: Box<MatcherTradeEvent>) -> Self {
+        let tail = Self::find_tail(&mut event);
+        let tail = (tail as *mut MatcherTradeEvent) as usize;
+        Self { head: event, tail }
+    }
+
+    fn push(&mut self, mut event: Box<MatcherTradeEvent>) {
+        if self.tail == 0 {
+            let tail = Self::find_tail(&mut self.head);
+            self.tail = (tail as *mut MatcherTradeEvent) as usize;
+        }
+        let next_tail = Self::find_tail(&mut event);
+        let next_tail = (next_tail as *mut MatcherTradeEvent) as usize;
+
+        // SAFETY: `tail` points into the linked list owned by `head`. Nodes are heap allocated,
+        // so moving the chain does not move them, and mutation requires exclusive access here.
+        unsafe {
+            (*(self.tail as *mut MatcherTradeEvent)).next_event = Some(event);
+        }
+        self.tail = next_tail;
+    }
+
+    fn find_tail(mut event: &mut MatcherTradeEvent) -> &mut MatcherTradeEvent {
+        loop {
+            if event.next_event.is_none() {
+                return event;
+            }
+            event = event.next_event.as_deref_mut().unwrap();
+        }
+    }
+}
+
+impl Clone for MatcherTradeEventChain {
+    fn clone(&self) -> Self {
+        let mut head = self.head.clone();
+        let tail = Self::find_tail(&mut head);
+        let tail = (tail as *mut MatcherTradeEvent) as usize;
+        Self { head, tail }
+    }
+}
+
+impl fmt::Debug for MatcherTradeEventChain {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.head.fmt(formatter)
+    }
+}
+
+impl Deref for MatcherTradeEventChain {
+    type Target = MatcherTradeEvent;
+
+    fn deref(&self) -> &Self::Target {
+        &self.head
+    }
+}
+
+impl DerefMut for MatcherTradeEventChain {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        // The caller can change `next_event`, so force the next append to rebuild the tail.
+        self.tail = 0;
+        &mut self.head
     }
 }
 
@@ -504,5 +572,130 @@ mod tests {
 
             assert!(decode_order_command(&buf).is_err());
         }
+    }
+
+    use super::{MatcherTradeEvent, OrderCommand};
+
+    fn event_chain(matched_order_ids: &[u64]) -> Box<MatcherTradeEvent> {
+        let mut next_event = None;
+        for &matched_order_id in matched_order_ids.iter().rev() {
+            next_event = Some(Box::new({
+                // MatcherTradeEvent implements Drop (PR #179): no functional update.
+                let mut e = MatcherTradeEvent::default();
+                e.matched_order_id = matched_order_id;
+                e.next_event = next_event;
+                e
+            }));
+        }
+        next_event.unwrap()
+    }
+
+    fn matched_order_ids(command: &OrderCommand) -> Vec<u64> {
+        let mut matched_order_ids = Vec::new();
+        let mut current = command.events();
+        while let Some(event) = current {
+            matched_order_ids.push(event.matched_order_id);
+            current = event.next_event.as_deref();
+        }
+        matched_order_ids
+    }
+
+    #[test]
+    fn attach_event_preserves_order_for_many_fills() {
+        let mut command = OrderCommand::default();
+
+        for matched_order_id in 1..=500 {
+            command.attach_event(Box::new({
+                // MatcherTradeEvent implements Drop (PR #179): no functional update.
+                let mut e = MatcherTradeEvent::default();
+                e.matched_order_id = matched_order_id;
+                e.size = matched_order_id;
+                e
+            }));
+        }
+
+        let mut current = command.events();
+        let mut expected_order_id = 1;
+        while let Some(event) = current {
+            assert_eq!(event.matched_order_id, expected_order_id);
+            assert_eq!(event.size, expected_order_id);
+            expected_order_id += 1;
+            current = event.next_event.as_deref();
+        }
+
+        assert_eq!(expected_order_id, 501);
+
+        let mut cloned = command.clone();
+        cloned.attach_event(Box::new({
+            // MatcherTradeEvent implements Drop (PR #179): no functional update.
+            let mut e = MatcherTradeEvent::default();
+            e.matched_order_id = 501;
+            e.size = 501;
+            e
+        }));
+        assert_eq!(cloned.events().unwrap().calc_filled_size(), 125_751);
+        assert_eq!(command.events().unwrap().calc_filled_size(), 125_250);
+    }
+
+    #[test]
+    fn attach_event_rebuilds_tail_after_mutating_the_chain() {
+        let mut command = OrderCommand::default();
+        for matched_order_id in 1..=3 {
+            command.attach_event(Box::new({
+                // MatcherTradeEvent implements Drop (PR #179): no functional update.
+                let mut e = MatcherTradeEvent::default();
+                e.matched_order_id = matched_order_id;
+                e
+            }));
+        }
+
+        command.events_mut().unwrap().next_event = None;
+        command.attach_event(Box::new({
+            // MatcherTradeEvent implements Drop (PR #179): no functional update.
+            let mut e = MatcherTradeEvent::default();
+            e.matched_order_id = 4;
+            e
+        }));
+
+        let head = command.events().unwrap();
+        assert_eq!(head.matched_order_id, 1);
+        assert_eq!(head.next_event.as_deref().unwrap().matched_order_id, 4);
+        assert!(head.next_event.as_deref().unwrap().next_event.is_none());
+    }
+
+    #[test]
+    fn attach_event_preserves_prelinked_nodes_and_length() {
+        let mut command = OrderCommand::default();
+        command.attach_event(event_chain(&[1]));
+        command.attach_event(event_chain(&[2, 3]));
+        command.attach_event(event_chain(&[4]));
+
+        let matched_order_ids = matched_order_ids(&command);
+        assert_eq!(matched_order_ids, [1, 2, 3, 4]);
+        assert_eq!(matched_order_ids.len(), 4);
+    }
+
+    #[test]
+    fn attach_event_preserves_order_across_prelinked_chains() {
+        let mut command = OrderCommand::default();
+        command.attach_event(event_chain(&[1, 2]));
+        command.attach_event(event_chain(&[3, 4, 5]));
+        command.attach_event(event_chain(&[6, 7]));
+
+        let matched_order_ids = matched_order_ids(&command);
+        assert_eq!(matched_order_ids, [1, 2, 3, 4, 5, 6, 7]);
+        assert_eq!(matched_order_ids.len(), 7);
+    }
+
+    #[test]
+    fn attach_event_recomputes_actual_tail_after_mutable_access() {
+        let mut command = OrderCommand::default();
+        command.attach_event(event_chain(&[1, 2]));
+
+        let _ = command.events_mut();
+        command.attach_event(event_chain(&[3, 4]));
+        command.attach_event(event_chain(&[5]));
+
+        assert_eq!(matched_order_ids(&command), [1, 2, 3, 4, 5]);
     }
 }

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -9,8 +9,8 @@ mod snowflake;
 mod user_profile;
 
 pub use cmd::{
-    FRAMESIZE, MatcherTradeEvent, ORDERCOMMANDSIZE, OrderCommand, Status, decode_order_command,
-    encode_order_command,
+    FRAMESIZE, MatcherTradeEvent, MatcherTradeEventChain, ORDERCOMMANDSIZE, OrderCommand, Status,
+    decode_order_command, encode_order_command,
 };
 pub use core_arithmetic::CoreArithmetic;
 pub use events::{

--- a/networking/src/server/cmd_handler.rs
+++ b/networking/src/server/cmd_handler.rs
@@ -17,7 +17,7 @@ impl AeronFragmentHandlerCallback for FragmentHandler {
             Ok(mut order_command) => {
                 order_command.status = Status::Processing;
                 order_command.route_gateway_id = self.gateway_id;
-                info!(
+                debug!(
                     target: "order_command",
                     gateway_id = self.gateway_id,
                     client_order_id = ?order_command,

--- a/orderbook/src/lib.rs
+++ b/orderbook/src/lib.rs
@@ -45,6 +45,29 @@ use std::{
     sync::Arc,
 };
 
+macro_rules! error {
+    (
+        event = $event:literal,
+        price_level = $price_level:expr,
+        existing_total = $existing_total:expr,
+        $operand:ident = $amount:expr,
+        $message:literal
+    ) => {
+        eprintln!(
+            concat!(
+                "level=error event=",
+                $event,
+                " price_level={} existing_total={} ",
+                stringify!($operand),
+                "={} message=\"",
+                $message,
+                "\""
+            ),
+            $price_level, $existing_total, $amount
+        );
+    };
+}
+
 pub mod tree;
 mod unit_tests;
 
@@ -64,7 +87,17 @@ impl PriceLevel {
 
     #[inline]
     fn add_order(&mut self, order: Order) {
-        self.total_volume += order.size;
+        let existing_total = self.total_volume;
+        self.total_volume = existing_total.saturating_add(order.size);
+        if existing_total.checked_add(order.size).is_none() {
+            error!(
+                event = "price_level_volume_overflow",
+                price_level = order.price,
+                existing_total = existing_total,
+                addend = order.size,
+                "price level total volume overflowed; saturated at u64::MAX"
+            );
+        }
         self.orders.push_back(order);
     }
 
@@ -81,7 +114,17 @@ impl PriceLevel {
             }
 
             if let Some(removed_order) = self.orders.remove(pos) {
-                self.total_volume -= removed_order.size;
+                let existing_total = self.total_volume;
+                self.total_volume = existing_total.saturating_sub(removed_order.size);
+                if existing_total < removed_order.size {
+                    error!(
+                        event = "price_level_volume_underflow",
+                        price_level = removed_order.price,
+                        existing_total = existing_total,
+                        subtrahend = removed_order.size,
+                        "price level total volume underflowed; saturated at zero"
+                    );
+                }
                 cmd.set_price(removed_order.price);
                 cmd.set_size(removed_order.size);
                 cmd.set_user_id(removed_order.user_id);
@@ -174,7 +217,17 @@ impl<Ask: BookSide, Bid: BookSide> OrderBook<Ask, Bid> {
                 // Update sizes
                 remaining_size -= trade_size;
                 maker_order.size -= trade_size;
-                level.total_volume -= trade_size;
+                let existing_total = level.total_volume;
+                level.total_volume = existing_total.saturating_sub(trade_size);
+                if existing_total < trade_size {
+                    error!(
+                        event = "price_level_volume_underflow",
+                        price_level = price,
+                        existing_total = existing_total,
+                        subtrahend = trade_size,
+                        "price level total volume underflowed; saturated at zero"
+                    );
+                }
 
                 let maker_order_completed = maker_order.size == 0;
 
@@ -465,7 +518,16 @@ impl<Ask: BookSide, Bid: BookSide> OrderBook<Ask, Bid> {
 
     /// Create a snapshot of the orderbook data with specified depth
     pub fn record_snapshot(&self, cmd: &mut OrderCommand) {
-        let mut l2_data = L2MarketData::new();
+        let mut l2_data = L2MarketData {
+            ask_prices: Vec::with_capacity(L2SIZE),
+            ask_volumes: Vec::with_capacity(L2SIZE),
+            ask_orders: Vec::new(),
+            bid_prices: Vec::with_capacity(L2SIZE),
+            bid_volumes: Vec::with_capacity(L2SIZE),
+            bid_orders: Vec::new(),
+            timestamp: 0,
+            reference_seq: 0,
+        };
 
         // Fill bid levels (highest price first)
         for (price, level) in self.get_bids().take(L2SIZE) {
@@ -482,8 +544,7 @@ impl<Ask: BookSide, Bid: BookSide> OrderBook<Ask, Bid> {
         // Set timestamp
         l2_data.timestamp = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos() as u64;
+            .map_or(0, |elapsed| elapsed.as_nanos() as u64);
 
         cmd.l2_data = Some(l2_data);
     }

--- a/orderbook/src/unit_tests.rs
+++ b/orderbook/src/unit_tests.rs
@@ -297,6 +297,142 @@ mod test {
     }
 
     #[test]
+    fn price_level_volume_tracks_add_and_remove() {
+        let mut level = PriceLevel::new();
+        level.add_order(Order {
+            order_id: 1,
+            user_id: 1,
+            price: 100,
+            size: 25,
+            original_size: 25,
+            side: Side::Bid,
+            time_in_force: TimeInForce::Gtc,
+            status: Status::Placed,
+            timestamp: 0,
+        });
+        level.add_order(Order {
+            order_id: 2,
+            user_id: 2,
+            price: 100,
+            size: 75,
+            original_size: 75,
+            side: Side::Bid,
+            time_in_force: TimeInForce::Gtc,
+            status: Status::Placed,
+            timestamp: 0,
+        });
+        assert_eq!(level.get_total_volume(), 100);
+
+        // PR #148 makes remove_order owner-checked; these volume tests must claim the owner.
+        let mut command = OrderCommand {
+            user_id: 1,
+            ..Default::default()
+        };
+        level.remove_order(1, &mut command);
+        assert_eq!(level.get_total_volume(), 75);
+        assert_eq!(level.get_order_count(), 1);
+    }
+
+    #[test]
+    fn price_level_volume_overflow_saturates_without_panicking() {
+        let mut level = PriceLevel::new();
+        level.add_order(Order {
+            order_id: 1,
+            user_id: 1,
+            price: 100,
+            size: u64::MAX,
+            original_size: u64::MAX,
+            side: Side::Bid,
+            time_in_force: TimeInForce::Gtc,
+            status: Status::Placed,
+            timestamp: 0,
+        });
+        level.add_order(Order {
+            order_id: 2,
+            user_id: 2,
+            price: 100,
+            size: 1,
+            original_size: 1,
+            side: Side::Bid,
+            time_in_force: TimeInForce::Gtc,
+            status: Status::Placed,
+            timestamp: 0,
+        });
+
+        assert_eq!(level.get_total_volume(), u64::MAX);
+        assert_eq!(level.get_order_count(), 2);
+    }
+
+    #[test]
+    fn price_level_volume_underflow_saturates_without_panicking() {
+        let mut level = PriceLevel::new();
+        level.orders.push_back(Order {
+            order_id: 1,
+            user_id: 1,
+            price: 100,
+            size: 1,
+            original_size: 1,
+            side: Side::Bid,
+            time_in_force: TimeInForce::Gtc,
+            status: Status::Placed,
+            timestamp: 0,
+        });
+
+        // PR #148 makes remove_order owner-checked; these volume tests must claim the owner.
+        let mut command = OrderCommand {
+            user_id: 1,
+            ..Default::default()
+        };
+        level.remove_order(1, &mut command);
+
+        assert_eq!(level.get_total_volume(), 0);
+        assert_eq!(level.get_order_count(), 0);
+        assert_eq!(command.status, Status::Cancelled);
+    }
+
+    #[test]
+    fn record_snapshot_preserves_contents_without_unused_allocations() {
+        let (mut book, price_cache) = create_test_orderbook();
+        let mut bid = create_order_command(
+            OrderCommandType::PlaceOrder,
+            1,
+            100,
+            101,
+            10,
+            99,
+            25,
+            Side::Bid,
+            TimeInForce::Gtc,
+        );
+        book.place_order(&mut bid, Arc::clone(&price_cache));
+
+        let mut ask = create_order_command(
+            OrderCommandType::PlaceOrder,
+            2,
+            101,
+            102,
+            10,
+            101,
+            40,
+            Side::Ask,
+            TimeInForce::Gtc,
+        );
+        book.place_order(&mut ask, price_cache);
+
+        let snapshot = ask.l2_data.as_ref().unwrap();
+        assert_eq!(snapshot.bid_prices, [99]);
+        assert_eq!(snapshot.bid_volumes, [25]);
+        assert_eq!(snapshot.ask_prices, [101]);
+        assert_eq!(snapshot.ask_volumes, [40]);
+        assert!(snapshot.bid_orders.is_empty());
+        assert!(snapshot.ask_orders.is_empty());
+        assert_eq!(snapshot.bid_orders.capacity(), 0);
+        assert_eq!(snapshot.ask_orders.capacity(), 0);
+        assert_eq!(snapshot.reference_seq, 0);
+        assert_ne!(snapshot.timestamp, 0);
+    }
+
+    #[test]
     fn test_empty_orderbook_creation() {
         let (mut book, _) = create_test_orderbook();
         assert_eq!(book.total_order_count(), 0);

--- a/processors/src/events.rs
+++ b/processors/src/events.rs
@@ -7,7 +7,7 @@ use common::OrderCommand;
 use common::OrderCommandType;
 use common::Status;
 use common::UserBalance;
-use common::{base_asset, order_debug, order_info, quote_asset};
+use common::{base_asset, order_debug, quote_asset};
 use prost::Message;
 use rdkafka::config::ClientConfig;
 use rdkafka::producer::{FutureProducer, FutureRecord, Producer};
@@ -543,7 +543,7 @@ impl EventsHandler for KafkaEventsHandler {
             return;
         }
 
-        order_info!(
+        order_debug!(
             "command_processed",
             cmd,
             stage = "events",

--- a/processors/src/journaling.rs
+++ b/processors/src/journaling.rs
@@ -3,7 +3,7 @@ use std::sync::{
     atomic::{AtomicBool, Ordering},
 };
 
-use common::{OrderCommand, OrderCommandType, Snowflake, order_debug, order_info};
+use common::{OrderCommand, OrderCommandType, Snowflake, order_debug};
 use vex_networking::server::Publications;
 
 pub struct JournalingProcessor {
@@ -37,7 +37,7 @@ impl JournalingProcessor {
         }
         cmd.timestamp = self.snowflake.timestamp();
         self.publications.publish_to_archive(cmd);
-        order_info!("command_ingested", cmd, stage = "journal");
+        order_debug!("command_ingested", cmd, stage = "journal");
     }
 
     pub fn journal_event(&self, cmd: &mut OrderCommand) {

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -684,7 +684,7 @@ mod tests {
         );
         engine.handle_trade_event(seller_id, market_id, Side::Ask, &mut event, None);
 
-        // PR #163 rounds fees UP per fill (div_ceil), so this remainder costs one more
+        // PR #163 rounds fees UP per fill (div_ceil), so the remainder below costs one more
         // atomic unit than the pre-#163 floor of 666_666.
         let taker_fee_in_base = 666_667;
         assert_eq!((size * 20) % 10_000, 6_680);
@@ -702,7 +702,7 @@ mod tests {
         );
         // Gross quote here is one atomic unit. Pre-#163 the 10 bp maker fee floored to zero
         // and the seller kept the unit; with #163's per-fill div_ceil the fee is a whole unit,
-        // so the maker nets nothing. This is the ceil-per-fill overcharge tracked against #163.
+        // so the maker nets nothing. Same ceil-per-fill overcharge as the ask round-trip test.
         let maker_fee_in_quote = (quote_cost * 10).div_ceil(10_000);
         assert_eq!(
             engine.get_balance(seller_id, quote_asset_id),
@@ -755,7 +755,8 @@ mod tests {
         );
         // Gross quote is one atomic unit. Pre-#163 the 10 bp fee floored to zero and the
         // seller kept the unit; with #163's per-fill div_ceil the fee is one unit, i.e. the
-        // whole proceeds. Asserted explicitly so it cannot regress silently either way.
+        // whole proceeds. This is the ceil-per-fill overcharge tracked against #163 -- the
+        // stacked behaviour is asserted here so it cannot regress silently either way.
         assert_eq!(
             engine.get_balance(user_id, quote_asset_id),
             UserBalance::new(0, 0)


### PR DESCRIPTION
Four independent hot-path findings.

## 1. `attach_event` was O(n²) per order

It walked the event chain from the head for every appended fill. A 500-order sweep took
**235 µs** against a documented 50–70 µs p99 target.

`OrderCommand::events` becomes a `MatcherTradeEventChain` that keeps a tail pointer, so appending is
O(1) amortised and the whole sweep is O(n).

**Measured, release mode, same 500-order sweep shape, 100 samples:**

| | Before | After |
|---|---:|---:|
| Sweep median | 235.2 µs | **25.4 µs** |
| Append path alone | 196.5 µs | **14.8 µs** (13.3×) |

The `Box` per fill stays — `next_event: Option<Box<_>>` is the public ownership model and changing it
is a wider change than this warrants.

**One correction came out of review and is worth recording.** The first version took the tail as the
address of the incoming box, assuming it was a single node. `MatcherTradeEvent::next_event` is a
`pub` field and code constructs multi-node events directly (`processors/src/events.rs:794`), so
appending one of those would have left `tail` pointing at its head — and the next append would
overwrite that link, **silently dropping every trade after it** from the chain that feeds the `trades`
topic. `new` and `push` now locate the real tail of whatever they are given. `find_tail` is iterative,
not recursive, so it does not add a second stack-overflow path alongside the recursive `Drop` already
noted in #141.

## 2. `record_snapshot` allocated per order on the matching thread

Now only the populated price and volume vectors are allocated; `ask_orders` and `bid_orders` get zero
capacity. The `SystemTime` `unwrap()` is gone — a clock failure yields timestamp `0` rather than
killing the matching thread.

Codex's investigation corrected the issue text here: **two** of the vectors are always empty, not
four. Recorded so the count is not repeated as fact.

## 3. INFO logging per command on pinned pipeline threads

`cmd_handler.rs:17` `Debug`-formatted the entire `OrderCommand` for every inbound fragment;
`events.rs:531` and `journaling.rs:40` logged per command. All three serialise on the global stdout
mutex, on core-pinned threads.

All three demoted to `debug!`, so they remain available but are off by default. **Logs that report an
actual failure keep their level** — nothing that reports a problem was quietened.

## 4. `PriceLevel::total_volume` used unchecked `+=` / `-=`

It wrapped in release and panicked in debug. All three aggregate updates are now explicit:
`PriceLevel::add_order` (`orderbook/src/lib.rs:88`), `PriceLevel::remove_order`
(`orderbook/src/lib.rs:104`), and the maker-fill decrement inside `match_order`
(`orderbook/src/lib.rs:211`).

**The first version of this PR chose the wrong failure mode, and an earlier revision of this
description defended it as deliberate.** That version used `checked_add` / `checked_sub` with
`.expect("price level total volume overflow" / "underflow")`, and argued that panicking in release was
correct because a volume mismatch proves the book's accounting has already diverged from its orders.
Codex's review on `orderbook/src/lib.rs:69` showed that argument does not hold for the overflow side:

> When two balance-backed resting orders at the same price have sizes whose sum exceeds `u64::MAX`,
> both orders can pass the per-user risk checks, but the second order now reaches this `expect` and
> panics during order-book processing. Aggregate overflow does not imply that the book has already
> diverged, so it should be handled by a wider accumulator or by rejecting the incoming order rather
> than terminating the processing thread.

That is right. Two individually risk-approved orders resting at one price can sum past `u64::MAX`
without anything being corrupt — it is an aggregate-only limit, and killing the matching thread for it
converts a bookkeeping ceiling into an outage.

**Rejecting the incoming order, the reviewer's other suggestion, is not reachable from this call
site**, and the reason matters more than the mechanics:

- `add_to_book` takes `cmd: &OrderCommand` immutably (`orderbook/src/lib.rs:403`), so it cannot set a
  status at all.
- Even if it could, `place_order` overwrites the status on the very next line —
  `cmd.set_status(Status::Placed)` / `Status::PartiallyFilled`.
- Decisively: `Status::Rejected` does not release reserved funds. `create_risk_r2_handler!` returns
  early on `Rejected` before it reaches `handle_cancellation` (`server/src/utils.rs:64`). A reject
  raised here would leave the user's collateral reserved with no order behind it. Silently stranding
  money is a worse outcome than the panic it was meant to replace.

So all three sites saturate — `saturating_add` at `u64::MAX`, `saturating_sub` at zero — and emit a
structured error line naming the price level, the existing total and the operand, e.g.

```
level=error event=price_level_volume_overflow price_level=100 existing_total=18446744073709551615 addend=1 message="price level total volume overflowed; saturated at u64::MAX"
```

`vex-orderbook` depends only on `common` and pulls in no logging facade, so this is a small local
`error!` macro over `eprintln!` rather than a new dependency. It fires only on the failure path, so it
adds nothing to the hot path. The condition stays loud and greppable without taking the exchange down
for it; **this PR no longer panics in release on volume over/underflow.**

The `#[should_panic]` test the first commit added (`price_level_volume_underflow_is_loud`) went with
the panic. It is replaced by `price_level_volume_overflow_saturates_without_panicking` and
`price_level_volume_underflow_saturates_without_panicking`, which assert the saturated totals, the
resulting order counts, and that `remove_order` still reports `Status::Cancelled`.

## Verification

`cargo test --workspace`: 162 passed, 0 failed. clippy: 0 warnings. Against `develop`, **no existing
test body was changed** — `orderbook/src/unit_tests.rs` is additions only, and the one test that was
rewritten was added by this PR's own first commit. The observable matching behaviour is identical.

## Related

Closes #142

- vex-core #141 item 2 — unbounded recursive `Drop` on the event chain, deliberately untouched.
- vex-core #79 — snapshot allocation, referenced by item 2.
- vex-core #51 — logging levels, referenced by item 3.
- vex-core #129 / PR #156 — the panic containment that item 4's first version leaned on to justify
  aborting. Item 4 no longer panics, so it no longer depends on it.
