### PR TITLE
fix(ledger): consistent price snapshots, zero-price rejection, honest cancel status, bounded balance map

### DIFF
--- a/common/src/order.rs
+++ b/common/src/order.rs
@@ -44,6 +44,7 @@ impl Order {
 
 // Holds the top-of-book prices for a single symbol
 pub struct MarketPrice {
+    sequence: AtomicU64,
     pub best_bid: AtomicU64,
     pub best_ask: AtomicU64,
 }
@@ -54,6 +55,7 @@ impl Default for MarketPrice {
         // - No bid means price floor (0) - can't sell
         // - No ask means price ceiling (MAX) - can't buy
         Self {
+            sequence: AtomicU64::new(0),
             best_bid: AtomicU64::new(0),
             best_ask: AtomicU64::new(u64::MAX),
         }
@@ -74,29 +76,101 @@ impl PriceCache {
         Self { prices }
     }
 
+    /// Get a consistent best bid and ask snapshot for a symbol.
+    pub fn get_prices(&self, symbol: u32) -> Option<(u64, u64)> {
+        let market_price = self.prices.get(&symbol)?;
+
+        loop {
+            let sequence = market_price.sequence.load(Ordering::SeqCst);
+            if sequence % 2 != 0 {
+                std::hint::spin_loop();
+                continue;
+            }
+
+            let best_bid = market_price.best_bid.load(Ordering::SeqCst);
+            let best_ask = market_price.best_ask.load(Ordering::SeqCst);
+            if sequence == market_price.sequence.load(Ordering::SeqCst) {
+                return Some((best_bid, best_ask));
+            }
+        }
+    }
+
     /// Get the best bid price for a symbol
     /// Retruns u64::MAX if no bid price is available
     pub fn get_best_bid(&self, symbol: u32) -> u64 {
-        match self.prices.get(&symbol) {
-            Some(market_price) => market_price.best_bid.load(Ordering::Acquire),
-            None => u64::MAX,
-        }
+        self.get_prices(symbol)
+            .map_or(u64::MAX, |(best_bid, _)| best_bid)
     }
 
     /// Get the best ask price for a symbol    
     /// Returns 0 if no ask price is available
     pub fn get_best_ask(&self, symbol: u32) -> u64 {
-        match self.prices.get(&symbol) {
-            Some(market_price) => market_price.best_ask.load(Ordering::Acquire),
-            None => 0,
-        }
+        self.get_prices(symbol).map_or(0, |(_, best_ask)| best_ask)
     }
 
     /// Update the best bid price for a symbol
-    /// If the symbol does not exist, it will be created
+    /// Missing symbols are ignored.
     pub fn update_prices(&self, symbol: u32, best_bid: u64, best_ask: u64) {
-        let market_price = self.prices.get(&symbol).unwrap();
-        market_price.best_bid.store(best_bid, Ordering::Release);
-        market_price.best_ask.store(best_ask, Ordering::Release);
+        let Some(market_price) = self.prices.get(&symbol) else {
+            return;
+        };
+
+        market_price.sequence.fetch_add(1, Ordering::SeqCst);
+        market_price.best_bid.store(best_bid, Ordering::SeqCst);
+        market_price.best_ask.store(best_ask, Ordering::SeqCst);
+        market_price.sequence.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{CoreMarketSpecification, MarketType};
+    use std::sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    };
+
+    fn price_cache(market_id: u32) -> PriceCache {
+        let mut specs = HashMap::new();
+        specs.insert(
+            market_id,
+            CoreMarketSpecification::builder()
+                .market_id(market_id)
+                .market_type(MarketType::Spot)
+                .build()
+                .unwrap(),
+        );
+        PriceCache::new(specs.keys())
+    }
+
+    #[test]
+    fn price_snapshot_cannot_be_torn() {
+        let market_id = 1;
+        let cache = Arc::new(price_cache(market_id));
+        let writer_cache = Arc::clone(&cache);
+        let writer_done = Arc::new(AtomicBool::new(false));
+        let writer_done_clone = Arc::clone(&writer_done);
+
+        let writer = std::thread::spawn(move || {
+            for best_bid in 1..=100_000 {
+                writer_cache.update_prices(market_id, best_bid, !best_bid);
+            }
+            writer_done_clone.store(true, Ordering::Release);
+        });
+
+        while !writer_done.load(Ordering::Acquire) {
+            let (best_bid, best_ask) = cache.get_prices(market_id).unwrap();
+            assert_eq!(best_ask, !best_bid);
+        }
+
+        writer.join().unwrap();
+    }
+
+    #[test]
+    fn updating_a_missing_market_does_not_panic() {
+        let cache = price_cache(1);
+        cache.update_prices(2, 10, 11);
+        assert_eq!(cache.get_prices(2), None);
     }
 }

--- a/common/src/user_profile.rs
+++ b/common/src/user_profile.rs
@@ -78,9 +78,20 @@ impl BalanceStore {
             .ok_or(BalanceError::UserAssetNotFound(user_id, asset_id))
     }
 
-    pub fn get_balance_mut(&mut self, user_id: u64, asset_id: u16) -> &mut UserBalance {
+    pub fn get_balance_mut(
+        &mut self,
+        user_id: u64,
+        asset_id: u16,
+    ) -> Result<&mut UserBalance, BalanceError> {
         let key = BalanceKey { user_id, asset_id };
-        self.balances.entry(key).or_default()
+        self.balances
+            .get_mut(&key)
+            .ok_or(BalanceError::UserAssetNotFound(user_id, asset_id))
+    }
+
+    pub fn set_balance(&mut self, user_id: u64, asset_id: u16, balance: UserBalance) {
+        let key = BalanceKey { user_id, asset_id };
+        self.balances.insert(key, balance);
     }
 
     // Lock funds (move from available to locked)
@@ -90,10 +101,15 @@ impl BalanceStore {
         asset_id: u16,
         amount: u64,
     ) -> Result<(), BalanceError> {
-        let balance = self.get_balance_mut(user_id, asset_id);
+        let balance = self.get_balance_mut(user_id, asset_id)?;
         if balance.available >= amount {
-            balance.available -= amount;
-            balance.locked += amount;
+            let available = balance.available - amount;
+            let locked = balance
+                .locked
+                .checked_add(amount)
+                .ok_or(BalanceError::Overflow)?;
+            balance.available = available;
+            balance.locked = locked;
             Ok(())
         } else {
             Err(BalanceError::InsufficientAvailableFunds {
@@ -110,10 +126,15 @@ impl BalanceStore {
         asset_id: u16,
         amount: u64,
     ) -> Result<(), BalanceError> {
-        let balance = self.get_balance_mut(user_id, asset_id);
+        let balance = self.get_balance_mut(user_id, asset_id)?;
         if balance.locked >= amount {
-            balance.locked -= amount;
-            balance.available += amount;
+            let locked = balance.locked - amount;
+            let available = balance
+                .available
+                .checked_add(amount)
+                .ok_or(BalanceError::Overflow)?;
+            balance.locked = locked;
+            balance.available = available;
             Ok(())
         } else {
             Err(BalanceError::InsufficientLockedFunds {
@@ -130,7 +151,8 @@ impl BalanceStore {
         asset_id: u16,
         amount: u64,
     ) -> Result<UserBalance, BalanceError> {
-        let balance = self.get_balance_mut(user_id, asset_id);
+        let key = BalanceKey { user_id, asset_id };
+        let balance = self.balances.entry(key).or_default();
         balance.available = balance
             .available
             .checked_add(amount)
@@ -145,7 +167,7 @@ impl BalanceStore {
         asset_id: u16,
         amount: u64,
     ) -> Result<UserBalance, BalanceError> {
-        let balance = self.get_balance_mut(user_id, asset_id);
+        let balance = self.get_balance_mut(user_id, asset_id)?;
         if balance.available >= amount {
             balance.available -= amount;
             Ok(*balance)
@@ -164,7 +186,7 @@ impl BalanceStore {
         asset_id: u16,
         amount: u64,
     ) -> Result<UserBalance, BalanceError> {
-        let balance = self.get_balance_mut(user_id, asset_id);
+        let balance = self.get_balance_mut(user_id, asset_id)?;
         if balance.locked >= amount {
             balance.locked -= amount;
             Ok(*balance)
@@ -174,6 +196,51 @@ impl BalanceStore {
                 needed: amount,
             })
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejected_lock_does_not_insert_balance() {
+        let mut store = BalanceStore::new();
+
+        assert_eq!(
+            store.lock_funds(7, 3, 1),
+            Err(BalanceError::UserAssetNotFound(7, 3))
+        );
+        assert!(store.balances.is_empty());
+    }
+
+    #[test]
+    fn rejected_unlock_does_not_insert_balance() {
+        let mut store = BalanceStore::new();
+
+        assert_eq!(
+            store.unlock_funds(7, 3, 1),
+            Err(BalanceError::UserAssetNotFound(7, 3))
+        );
+        assert!(store.balances.is_empty());
+    }
+
+    #[test]
+    fn lock_funds_checks_locked_overflow_without_mutation() {
+        let mut store = BalanceStore::new();
+        store.set_balance(7, 3, UserBalance::new(1, u64::MAX));
+
+        assert_eq!(store.lock_funds(7, 3, 1), Err(BalanceError::Overflow));
+        assert_eq!(store.get_balance(7, 3), UserBalance::new(1, u64::MAX));
+    }
+
+    #[test]
+    fn unlock_funds_checks_available_overflow_without_mutation() {
+        let mut store = BalanceStore::new();
+        store.set_balance(7, 3, UserBalance::new(u64::MAX, 1));
+
+        assert_eq!(store.unlock_funds(7, 3, 1), Err(BalanceError::Overflow));
+        assert_eq!(store.get_balance(7, 3), UserBalance::new(u64::MAX, 1));
     }
 }
 

--- a/processors/src/risk_engine.rs
+++ b/processors/src/risk_engine.rs
@@ -350,11 +350,15 @@ impl RiskEngine {
             .checked_add(amount_to_add)
             .ok_or(BalanceError::Overflow)?;
 
+        // PR #178 made get_balance_mut fallible so a REJECTED operation can no longer insert
+        // an empty row. This is the commit point: every validation above has passed, so the
+        // write must succeed even for an asset the user is receiving for the first time.
+        // set_balance inserts-or-updates, keeping PR #153's all-or-nothing commit intact.
         if asset_to_add == asset_to_subtract {
-            *store.get_balance_mut(user_id, asset_to_add) = balance_add;
+            store.set_balance(user_id, asset_to_add, balance_add);
         } else {
-            *store.get_balance_mut(user_id, asset_to_subtract) = balance_sub;
-            *store.get_balance_mut(user_id, asset_to_add) = balance_add;
+            store.set_balance(user_id, asset_to_subtract, balance_sub);
+            store.set_balance(user_id, asset_to_add, balance_add);
         }
 
         if let (Some(fees), Some(total)) = (accrued_fees.as_mut(), accrued_fee_total) {
@@ -407,6 +411,7 @@ impl RiskEngine {
                 "[RiskEngine_{}] Failed to release funds for cancelled order {}: {:?}",
                 self.shard_id, cmd.order_id, err
             );
+            cmd.set_status(Status::Rejected);
         } else {
             info!(
                 "[RiskEngine_{}] Successfully released funds for cancelled order {}",
@@ -487,9 +492,11 @@ impl RiskEngine {
         if cmd.price == u64::MAX {
             // Market buy order
             let slippage = spec.slippage;
-            let best_ask = price_cache.get_best_ask(cmd.market_id);
+            let best_ask = price_cache
+                .get_prices(cmd.market_id)
+                .map_or(0, |(_, best_ask)| best_ask);
 
-            if best_ask == u64::MAX {
+            if best_ask == 0 || best_ask == u64::MAX {
                 // No liquidity on ask side (sentinel value), cannot determine price for market order.
                 return Err(RiskEngineError::InvalidArguments {
                     price: cmd.price,
@@ -606,7 +613,7 @@ impl RiskEngine {
 
     pub fn set_balance(&self, user_id: u64, asset_id: u16, balance: UserBalance) {
         let mut store = self.balances.lock();
-        *store.get_balance_mut(user_id, asset_id) = balance;
+        store.set_balance(user_id, asset_id, balance);
     }
 
     /// Handles deposit funds command
@@ -1165,6 +1172,27 @@ mod tests {
     }
 
     #[test]
+    fn failed_cancellation_release_is_rejected() {
+        let user_id = 1;
+        let market_id = (2_u32 << 16) | 1_u32;
+        let mut specs = HashMap::new();
+        specs.insert(market_id, get_spec(market_id));
+        let engine = RiskEngine::new(specs, 0, 1);
+        // PR #171 made the BID path release only what was actually tracked, so a missing
+        // collateral record is deliberately NOT an error (see
+        // test_bid_cancel_without_collateral_record_is_safe). The ASK path still unlocks base
+        // directly, so it is the case that genuinely fails and must surface as Rejected --
+        // which is the guarantee PR #178 is about.
+        let mut cmd =
+            OrderCommand::place_order(TimeInForce::Gtc, user_id, 100, 10, Side::Ask, market_id, 1);
+        cmd.set_status(Status::Cancelled);
+
+        engine.handle_cancellation(&mut cmd);
+
+        assert_eq!(cmd.status, Status::Rejected);
+    }
+
+    #[test]
     fn test_insufficient_funds() {
         let user_id = 1;
         let market_id = (2_u32 << 16) | 1_u32;
@@ -1229,9 +1257,16 @@ mod tests {
         let maker_initial_base = size;
 
         let mut balances = engine.balances.lock();
-        *balances.get_balance_mut(taker_id, usd_asset_id) =
-            UserBalance::new(taker_initial_quote, 0);
-        *balances.get_balance_mut(maker_id, btc_asset_id) = UserBalance::new(maker_initial_base, 0);
+        balances.set_balance(
+            taker_id,
+            usd_asset_id,
+            UserBalance::new(taker_initial_quote, 0),
+        );
+        balances.set_balance(
+            maker_id,
+            btc_asset_id,
+            UserBalance::new(maker_initial_base, 0),
+        );
         drop(balances);
 
         // --- Reserve funds ---
@@ -1527,6 +1562,38 @@ mod tests {
     }
 
     #[test]
+    fn market_buy_rejects_zero_reference_price() {
+        let user_id = 1;
+        let usd_asset_id = 1u16;
+        let btc_asset_id = 2u16;
+        let market_id = ((usd_asset_id as u32) << 16) | btc_asset_id as u32;
+        let mut specs = HashMap::new();
+        specs.insert(market_id, get_spec(market_id));
+        let price_cache = Arc::new(PriceCache::new(specs.keys()));
+        price_cache.update_prices(market_id, 0, 0);
+        let engine = RiskEngine::new(specs, 0, 1);
+        engine.set_balance(user_id, usd_asset_id, UserBalance::new(1_000, 0));
+        let mut cmd = OrderCommand::place_order(
+            TimeInForce::Gtc,
+            user_id,
+            u64::MAX,
+            10,
+            Side::Bid,
+            market_id,
+            1,
+        );
+
+        assert!(matches!(
+            engine.reserve_funds_for_order(&mut cmd, price_cache),
+            Err(RiskEngineError::InvalidArguments { .. })
+        ));
+        assert_eq!(
+            engine.get_balance(user_id, usd_asset_id),
+            UserBalance::new(1_000, 0)
+        );
+    }
+
+    #[test]
     fn test_parallel_markets_and_settlement() {
         // This test simulates a user trading on two different markets concurrently.
         // It verifies that funds are locked, settled, and cancelled correctly across markets.
@@ -1550,9 +1617,9 @@ mod tests {
         // --- Initial Balances ---
         // User has 100,000,000 USD, 10,000 BTC, 50,000 ETH
         let mut balances = engine.balances.lock();
-        *balances.get_balance_mut(user_id, usd_asset_id) = UserBalance::new(100_000_000, 0);
-        *balances.get_balance_mut(user_id, btc_asset_id) = UserBalance::new(10_000, 0);
-        *balances.get_balance_mut(user_id, eth_asset_id) = UserBalance::new(50_000, 0);
+        balances.set_balance(user_id, usd_asset_id, UserBalance::new(100_000_000, 0));
+        balances.set_balance(user_id, btc_asset_id, UserBalance::new(10_000, 0));
+        balances.set_balance(user_id, eth_asset_id, UserBalance::new(50_000, 0));
         drop(balances);
 
         // --- Action 1: User places a BID order on BTC/USD market ---


### PR DESCRIPTION
Six grouped ledger and settlement findings. Four fixed, one skipped as already fixed elsewhere, one
declined with reasons.

## 1. Truncation residue permanently locked — **skipped, already fixed**

Fixed by the open PR for #169, which tracks the exact amount locked per BID order and releases that
instead of recomputing it. Deliberately not reimplemented here — a second mechanism for the same
invariant is worse than one.

## 2. `PriceCache` torn reads and a panic on a missing market — **fixed**

`update_prices` wrote `best_bid` and `best_ask` as two independent atomics, so a reader could observe
one market's bid paired with another update's ask — a price pair that never existed. It also
`unwrap()`ed on a missing market.

`MarketPrice` gains a **sequence counter** (a seqlock): the writer makes it odd for the duration of
the update, and `get_prices` re-reads it after loading both values and retries if it changed. A
reader therefore only ever sees a pair from one completed update. **No lock was added** — the
matching path stays lock-free, which was the constraint. A missing market is now a no-op rather than
a panic.

`get_best_bid` and `get_best_ask` are unchanged in behaviour; they now read through the consistent
snapshot.

## 3. R1 locks for order n+1 before R2 settles order n — **declined, with reasons**

The reinvestment guarantee this asks for requires `R2(n) ≺ R1(n+1)`. That collapses the pipeline's
overlap: R1 for every subsequent order would wait on R2 of the previous one, serialising the stages
the disruptor exists to run concurrently. There is no local ledger fix — the ordering *is* the
design.

The same reasoning applies to the scheduling half of item 2: making a market BUY's lock price
deterministic across a replay would need `Matching(n) ≺ R1(n+1)` or journaling moved, which is the
same restructuring.

Both are genuine, and both are pipeline-topology decisions rather than bugs to patch. Recorded here
so the trade-off is on the record rather than rediscovered.

## 4. `bid_amount` guarded only the `u64::MAX` sentinel — **fixed**

A `best_ask` of 0 made every market BUY lock zero collateral. Both sentinel values are now rejected
through the existing `InvalidArguments` path — no new error type.

## 5. `handle_cancellation` ignored a failed release — **fixed**

The client was told `Cancelled` while the funds stayed locked. A failed release now sets
`Status::Rejected`, so the client is not told its order was cancelled when it was not.

## 6. `BalanceStore::get_balance_mut` inserted before validation — **fixed**

`entry().or_default()` created a balance row for any user id that reached it, so rejected orders for
non-existent users grew the map without bound — an unauthenticated memory-growth vector while #114
was open. A missing balance now returns `UserAssetNotFound` and inserts nothing. `lock_funds` and
`unlock_funds` use checked arithmetic and leave the balance untouched on overflow rather than
wrapping.

## Verification

`cargo test -p processors -p vex-server -p common`: 46 passed, 0 failed. clippy: 0 warnings.
Includes a torn-read test that fails against two independent atomics.

## Related

Closes #140

- vex-core #169 / PR #171 — item 1.
- vex-core #114 / PR #176 — item 6's growth vector is only reachable pre-authentication.
- vex-core #128 — the pipeline aliasing question, which item 3's ordering discussion touches.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency when reading bid and ask prices during concurrent updates.
  * Missing market symbols are now handled safely without errors.
  * Balance operations report missing assets correctly and prevent changes when an overflow would occur.
  * Failed cancellations are marked as rejected.
  * Market-buy reservations now reject zero or unavailable reference prices.
* **Improvements**
  * Added explicit support for setting or replacing account balances.
  * New balance records are created only during valid fund additions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->