### PR TITLE
fix(networking): bound gateway ids, drop event chains iteratively, timeout startup, size ports correctly

### DIFF
--- a/common/src/cmd.rs
+++ b/common/src/cmd.rs
@@ -355,6 +355,15 @@ pub struct MatcherTradeEvent {
     pub maker_original_size: u64,
 }
 
+impl Drop for MatcherTradeEvent {
+    fn drop(&mut self) {
+        let mut next = self.next_event.take();
+        while let Some(mut event) = next {
+            next = event.next_event.take();
+        }
+    }
+}
+
 impl MatcherTradeEvent {
     pub fn calc_filled_size(&self) -> u64 {
         let mut size = 0;
@@ -409,4 +418,21 @@ pub fn decode_order_command(buf: &[u8]) -> Result<OrderCommand, SerdeError> {
         route_gateway_id: 0,
         original_size: 0,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deep_matcher_trade_event_chain_drops_iteratively() {
+        let mut chain = None;
+        for _ in 0..100_000 {
+            let mut event = MatcherTradeEvent::default();
+            event.next_event = chain;
+            chain = Some(Box::new(event));
+        }
+
+        drop(chain);
+    }
 }

--- a/networking/src/server/gateway_manager.rs
+++ b/networking/src/server/gateway_manager.rs
@@ -33,6 +33,12 @@ enum GatewaySlotState {
     Live,
 }
 
+const PORTS_PER_GATEWAY: usize = 2;
+
+fn gateway_port_capacity(max_gateways: u16) -> usize {
+    usize::from(max_gateways) * PORTS_PER_GATEWAY
+}
+
 pub struct Session {
     slots: [Option<GatewaySlot>; MAX_GATEWAYS],
 }
@@ -285,7 +291,7 @@ impl GatewayManager {
             aeron,
             port_allocator: PortAllocator::new(
                 config.base_gateway_port,
-                config.max_gateways.into(),
+                gateway_port_capacity(config.max_gateways),
             )
             .map_err(|e| ServerError::ResourceAllocationError(e.to_string()))?,
             session_allocator: SessionAllocator::new(
@@ -817,7 +823,7 @@ impl GatewayManager {
                         .take()
                         .expect("checked dedicated publication"),
                 ),
-            );
+            )?;
             pending.session_attached = true;
 
             debug!(
@@ -908,7 +914,7 @@ impl GatewayManager {
         };
 
         // remove publication
-        self.publications.remove(gateway_id);
+        self.publications.remove(gateway_id)?;
 
         // close subscription
         if let Some(mut session) = slot.duologue
@@ -1026,5 +1032,16 @@ mod tests {
 
         assert!(authenticate_gateway(&key, 987654321).is_err());
         assert!(!sessions.is_gateway_connected(1));
+    }
+
+    #[test]
+    fn port_allocator_has_two_ports_for_every_gateway() {
+        let allocator = PortAllocator::new(
+            10_000,
+            gateway_port_capacity(MAX_GATEWAYS.try_into().unwrap()),
+        )
+        .unwrap();
+
+        assert_eq!(allocator.total_ports(), MAX_GATEWAYS * PORTS_PER_GATEWAY);
     }
 }

--- a/networking/src/server/gateway_publications.rs
+++ b/networking/src/server/gateway_publications.rs
@@ -4,7 +4,9 @@ use rusteron_archive::{AeronPublication, AeronReservedValueSupplierLogger};
 use std::sync::Arc;
 use tracing::{debug, error};
 
-/// Manages Gateway Publications from gateway id 0 to MAX_GATEWAYS
+use super::ServerError;
+
+/// Manages Gateway Publications from gateway id 0 to MAX_GATEWAYS - 1
 /// Index MAX_GATEWAYS is reserved for archival publication
 pub struct Publications {
     gateways: [ArcSwapOption<AeronPublication>; MAX_GATEWAYS + 1],
@@ -25,29 +27,48 @@ impl Publications {
         self.gateways[MAX_GATEWAYS].store(Some(Arc::new(publication)));
     }
 
-    pub fn set(&self, gateway_id: u8, publication: Arc<AeronPublication>) {
-        self.gateways[gateway_id as usize].store(Some(publication));
+    pub fn set(
+        &self,
+        gateway_id: u8,
+        publication: Arc<AeronPublication>,
+    ) -> Result<(), ServerError> {
+        let index = Self::gateway_index(gateway_id)?;
+        self.gateways[index].store(Some(publication));
+        Ok(())
     }
 
-    pub fn get(&self, gateway_id: u8) -> Option<Arc<AeronPublication>> {
-        self.gateways[gateway_id as usize].load_full()
+    pub fn get(&self, gateway_id: u8) -> Result<Option<Arc<AeronPublication>>, ServerError> {
+        let index = Self::gateway_index(gateway_id)?;
+        Ok(self.gateways[index].load_full())
     }
 
-    pub fn remove(&self, gateway_id: u8) {
-        self.gateways[gateway_id as usize].store(None);
+    pub fn remove(&self, gateway_id: u8) -> Result<(), ServerError> {
+        let index = Self::gateway_index(gateway_id)?;
+        self.gateways[index].store(None);
+        Ok(())
+    }
+
+    fn gateway_index(gateway_id: u8) -> Result<usize, ServerError> {
+        let index = usize::from(gateway_id);
+        if index >= MAX_GATEWAYS {
+            return Err(ServerError::GatewayMessageError(format!(
+                "Gateway ID {gateway_id} out of range (max: {})",
+                MAX_GATEWAYS - 1
+            )));
+        }
+        Ok(index)
     }
 
     // Publisher (event handler thread)
     pub fn publish_response(&self, cmd: &OrderCommand) {
         let gateway_id = cmd.route_gateway_id;
-        if (gateway_id as usize) >= MAX_GATEWAYS {
-            error!(
-                "gateway-{}: invalid gateway id to send response",
-                gateway_id
-            );
-            return;
-        }
-        let ptr = self.get(gateway_id);
+        let ptr = match self.get(gateway_id) {
+            Ok(ptr) => ptr,
+            Err(e) => {
+                error!("gateway-{gateway_id}: invalid gateway id to send response: {e}");
+                return;
+            }
+        };
         let publication = ptr.as_ref();
         if publication.is_none() {
             error!(
@@ -88,7 +109,7 @@ impl Publications {
     // Publisher (event handler thread)
     pub fn publish_to_archive(&self, cmd: &OrderCommand) {
         let gateway_id = cmd.order_id;
-        let ptr = self.get(MAX_GATEWAYS as u8);
+        let ptr = self.gateways[MAX_GATEWAYS].load_full();
         let publication = ptr.as_ref();
         if publication.is_none() {
             error!(
@@ -129,5 +150,20 @@ impl Publications {
 impl Default for Publications {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_out_of_range_gateway_id() {
+        let publications = Publications::new();
+
+        assert!(matches!(
+            publications.get(MAX_GATEWAYS as u8),
+            Err(ServerError::GatewayMessageError(_))
+        ));
     }
 }

--- a/networking/src/server/mod.rs
+++ b/networking/src/server/mod.rs
@@ -54,7 +54,7 @@ use rusteron_media_driver::AeronIdleStrategy;
 use std::rc::Rc;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use thiserror::Error;
 use tracing::{debug, error, info, warn};
 use vex_config::{CoreNetworkingConfig, GatewayAuthenticationKey};
@@ -70,6 +70,7 @@ const RECORDING_STREAM_ID: i32 = 2001;
 pub const REPLAY_STREAM_ID: i32 = 2002;
 /// Channel for Aeron Recording also known as Aeron Control Channel
 const RECORDING_CHANNEL: &str = "aeron:ipc";
+const STARTUP_CONNECTION_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Error types for VEX Core server operations
 #[derive(Error, Debug)]
@@ -90,6 +91,32 @@ pub enum ServerError {
     CapacityExceededError(String),
     #[error("Configuration error: {0}")]
     ConfigurationError(String),
+    #[error("{0} did not connect within 10 seconds")]
+    StartupConnectionTimeout(&'static str),
+}
+
+fn wait_for_startup_connection(
+    resource: &'static str,
+    mut is_connected: impl FnMut() -> bool,
+) -> Result<(), ServerError> {
+    let start = Instant::now();
+    while !is_connected() {
+        if start.elapsed() >= STARTUP_CONNECTION_TIMEOUT {
+            return Err(ServerError::StartupConnectionTimeout(resource));
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    Ok(())
+}
+
+fn should_log_poll_error(last_error: &mut Option<String>, error: impl std::fmt::Display) -> bool {
+    let error = error.to_string();
+    if last_error.as_ref() == Some(&error) {
+        false
+    } else {
+        *last_error = Some(error);
+        true
+    }
 }
 
 /// Enhanced VEX Core server for handling gateway connections
@@ -159,15 +186,9 @@ impl VexCoreServer {
                 Duration::from_secs(1),
             )?;
 
-            // wait for publication to be connected
-            while !archive_publication.is_connected() {
-                std::thread::sleep(Duration::from_millis(100));
-                info!(
-                    target: "core_server",
-                    action = "archive_publication_wait",
-                    core_id = %config.core_id
-                );
-            }
+            wait_for_startup_connection("archive publication", || {
+                archive_publication.is_connected()
+            })?;
 
             publications.set_archive_publication(archive_publication);
 
@@ -244,27 +265,39 @@ impl VexCoreServer {
         // Main Message Polling Loop
         // 1. Listens for new handshakes
         // 2. Listens for new orders
+        let mut last_subscription_poll_error = None;
+        let mut last_gateway_poll_error = None;
         loop {
             if self.shutdown.load(Ordering::Acquire) {
                 return self.shutdown();
             }
 
-            if let Err(e) = self.subscription.poll(Some(&self.handshake_handler), 10) {
-                error!(
-                    target: "core_server",
-                    action = "poll_subscription_failed",
-                    core_id = %self.config.core_id,
-                    error = %e
-                );
+            match self.subscription.poll(Some(&self.handshake_handler), 10) {
+                Ok(_) => last_subscription_poll_error = None,
+                Err(e) => {
+                    if should_log_poll_error(&mut last_subscription_poll_error, &e) {
+                        error!(
+                            target: "core_server",
+                            action = "poll_subscription_failed",
+                            core_id = %self.config.core_id,
+                            error = %e
+                        );
+                    }
+                }
             }
 
-            if let Err(e) = self.gateways.poll() {
-                error!(
-                    target: "core_server",
-                    action = "poll_gateways_failed",
-                    core_id = %self.config.core_id,
-                    error = %e
-                );
+            match self.gateways.poll() {
+                Ok(()) => last_gateway_poll_error = None,
+                Err(e) => {
+                    if should_log_poll_error(&mut last_gateway_poll_error, &e) {
+                        error!(
+                            target: "core_server",
+                            action = "poll_gateways_failed",
+                            core_id = %self.config.core_id,
+                            error = %e
+                        );
+                    }
+                }
             }
 
             AeronIdleStrategy::busy_spinning_idle(std::ptr::null_mut(), 0);
@@ -532,13 +565,7 @@ impl VexCoreServer {
                 Duration::from_secs(5),
             )?;
 
-            while !subscription.is_connected() {
-                std::thread::sleep(Duration::from_millis(100));
-                debug!(
-                    target: "replay",
-                    action = "subscription_wait",
-                );
-            }
+            wait_for_startup_connection("replay subscription", || subscription.is_connected())?;
 
             let mut position = record.start_position;
             loop {
@@ -596,5 +623,20 @@ impl VexCoreServer {
     /// Gets core configuration
     pub fn config(&self) -> &CoreNetworkingConfig {
         &self.config
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::should_log_poll_error;
+
+    #[test]
+    fn poll_error_deduplication_keeps_first_occurrence_and_resets() {
+        let mut last_error = None;
+
+        assert!(should_log_poll_error(&mut last_error, "persistent error"));
+        assert!(!should_log_poll_error(&mut last_error, "persistent error"));
+        last_error = None;
+        assert!(should_log_poll_error(&mut last_error, "persistent error"));
     }
 }

--- a/networking/src/utils.rs
+++ b/networking/src/utils.rs
@@ -373,18 +373,19 @@ impl SessionAllocator {
     /// A new allocator
     ///
     /// # Errors
-    /// Returns `ResourceAllocationError` if max < min
+    /// Returns `ResourceAllocationError` if max <= min or the range is too large
     pub fn new(min: i32, max: i32) -> Result<Self, ServerError> {
         if max <= min {
             return Err(ServerError::ResourceAllocationError(format!(
-                "Maximum value {max} must be >= minimum value {min}"
+                "Maximum value {max} must be greater than minimum value {min}"
             )));
         }
 
-        Ok(Self {
-            min,
-            max_count: std::cmp::max(max - min, 1),
-        })
+        let max_count = max.checked_sub(min).ok_or_else(|| {
+            ServerError::ResourceAllocationError(format!("Session range {min}..{max} is too large"))
+        })?;
+
+        Ok(Self { min, max_count })
     }
 
     /// Allocate a new session, avoiding sessions already in use.
@@ -423,5 +424,20 @@ impl SessionAllocator {
     /// Get the maximum number of sessions that can be allocated
     pub fn max_sessions(&self) -> i32 {
         self.max_count
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn session_allocator_rejects_inverted_range() {
+        assert!(SessionAllocator::new(10, 9).is_err());
+    }
+
+    #[test]
+    fn session_allocator_rejects_range_that_exceeds_i32_capacity() {
+        assert!(SessionAllocator::new(i32::MIN, i32::MAX).is_err());
     }
 }


### PR DESCRIPTION
Six grouped Aeron transport findings. Four fixed, one skipped as already fixed, one declined.

## 1. `Publications` indexed a fixed array by `gateway_id` with no bound check — **fixed**

Every current caller happened to be guarded, but the invariant was unenforced at the API boundary —
one unguarded caller away from an index panic on the ingress thread. `set`, `get` and `remove` now
reject `gateway_id >= MAX_GATEWAYS` and return an error rather than indexing.

## 2. Unbounded recursive `Drop` on the event chain — **fixed**

When a ring slot was reused, the previous lap's `MatcherTradeEvent` chain was freed by recursive
`Drop` **on the Aeron ingress thread**. A deep chain — a large sweep across many price levels —
could overflow the stack and take the process down at exactly the moment it was busiest.

`Drop` is now iterative: it walks the chain taking each `next_event` in a loop. A regression test
drops a 100,000-node chain, which the recursive version cannot survive.

## 3. Unbounded startup wait and an error storm in the poll loop — **fixed**

The archive and replay startup waited on `is_connected()` with **no timeout**, so a misconfigured
archive hung the engine at boot with no diagnosis. It now times out after a private 10-second
constant and fails with a clear error.

The main poll loop re-logged errors at busy-spin frequency — millions of lines a second for a
persistent fault, which fills a disk and hides everything else. The first occurrence is logged and
subsequent identical errors are suppressed; a recovery resets the de-duplication so a **new**
occurrence is reported. Nothing is lost, the storm is.

## 4. Port allocator sized for one port per gateway — **fixed**

`PortAllocator` was sized with `max_gateways`, but each gateway consumes **two** ports (data and
control), so effective capacity was half the configured maximum — the engine would run out of ports
at 8 gateways with `MAX_GATEWAYS = 16`. Capacity is now `2 × max_gateways`.

`SessionAllocator::new` also computed `max - min` unchecked and overflowed on an inverted range. It
now rejects inverted or overflowing ranges instead.

## 5. `send_message_with_retries` sleeping in the poll callback — **skipped, already fixed**

The only server-side caller is the handshake path, which the open PR for #125 made non-blocking. The
identically-named client method is a different call site and is not on the server poll callback.
Verified rather than assumed; no second fix written.

## 6. The dedicated per-gateway channel is guarded only by a session id — **declined, with reasons**

The session id is handed back in a plaintext handshake response, so anyone who observes it can use
the channel. Closing this needs an authenticated, encrypted transport — key handling, integrity and
replay protection, and a compatible protocol change on both sides.

The shared key added by #114 / PR #176 does not cover it: that authenticates the *handshake*, and
the channel itself stays plaintext. Worth being explicit, because it would be easy to assume #114
closed this.

## Verification

`cargo test -p vex-networking -p common`: 25 passed, 0 failed. clippy: 0 warnings. The SBE wire
format and `ORDERCOMMANDSIZE = 64` are unchanged.

## Related

Closes #141

- vex-core #125 / PR #174 — item 5, and the same ingress-thread-must-not-block principle.
- vex-core #114 / PR #176 — handshake authentication, which does **not** close item 6.
- vex-core #142 / PR #177 — also touches `common/src/cmd.rs`, changing `OrderCommand::events` to a
  chain type. The two are semantically compatible — the iterative `Drop` here applies to the same
  nodes — but expect a textual conflict.
