### PR TITLE
fix(config): gate balance preload, honour the configured broker, surface disabled journaling

### DIFF
--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -73,6 +73,12 @@ impl RunningEngine {
 /// # }
 /// ```
 pub fn start(config: VexConfig, replay: bool) -> Result<RunningEngine, EngineError> {
+    config
+        .validate()
+        .map_err(|error| EngineError::Configuration(error.to_string()))?;
+
+    report_disabled_journaling(&config);
+
     #[allow(unused_mut)] // mut needed when balance-preload feature is enabled
     let ((engine, mut producer), replay_control) = init_internal(
         config.symbols.symbols.clone(),
@@ -117,6 +123,18 @@ pub fn start(config: VexConfig, replay: bool) -> Result<RunningEngine, EngineErr
         thread: thread_handle,
         shutdown_flag,
     })
+}
+
+fn report_disabled_journaling(config: &VexConfig) {
+    if config.core_networking.request_control_channel.is_empty() {
+        tracing::error!(
+            target: "server",
+            action = "journaling_disabled",
+            archive_recording = false,
+            environment = %config.environment,
+            "JOURNALING IS DISABLED: commands will not be recoverable by replay"
+        );
+    }
 }
 
 /// Internal initialization function
@@ -287,7 +305,64 @@ mod tests {
     use common::{MarketType, OrderCommand, PriceCache, Side, Status, TimeInForce, UserBalance};
     use disruptor::Producer;
     use processors::risk_engine::RiskEngine;
+    use std::sync::atomic::Ordering;
     use std::time::Duration;
+    use tracing::field::{Field, Visit};
+    use tracing::{Event, Level, Subscriber};
+    use tracing_subscriber::layer::{Context, SubscriberExt};
+    use tracing_subscriber::{Layer, Registry};
+
+    struct ActionVisitor {
+        journaling_disabled: bool,
+    }
+
+    impl Visit for ActionVisitor {
+        fn record_debug(&mut self, _field: &Field, _value: &dyn std::fmt::Debug) {}
+
+        fn record_str(&mut self, field: &Field, value: &str) {
+            if field.name() == "action" && value == "journaling_disabled" {
+                self.journaling_disabled = true;
+            }
+        }
+    }
+
+    struct DisabledJournalLayer(Arc<AtomicBool>);
+
+    impl<S: Subscriber> Layer<S> for DisabledJournalLayer {
+        fn on_event(&self, event: &Event<'_>, _context: Context<'_, S>) {
+            let mut visitor = ActionVisitor {
+                journaling_disabled: false,
+            };
+            event.record(&mut visitor);
+            if visitor.journaling_disabled && *event.metadata().level() == Level::ERROR {
+                self.0.store(true, Ordering::Relaxed);
+            }
+        }
+    }
+
+    #[test]
+    fn non_production_config_loudly_reports_disabled_journaling() {
+        let mut config = VexConfig::new(vex_config::Environment::Development);
+        config.core_networking.request_control_channel.clear();
+        let saw_error = Arc::new(AtomicBool::new(false));
+        let subscriber = Registry::default().with(DisabledJournalLayer(Arc::clone(&saw_error)));
+
+        assert!(config.validate().is_ok());
+        tracing::subscriber::with_default(subscriber, || report_disabled_journaling(&config));
+        assert!(saw_error.load(Ordering::Relaxed));
+    }
+
+    #[cfg(feature = "balance-preload")]
+    #[test]
+    fn production_balance_preload_is_rejected_before_startup() {
+        let mut config = VexConfig::new(vex_config::Environment::Production);
+        config.balance_preload.enabled = true;
+
+        assert!(matches!(
+            start(config, false),
+            Err(EngineError::Configuration(_))
+        ));
+    }
 
     /// Helper function to add a market specification to the specs map
     pub fn add_spec(market_id: u32, specs: &mut HashMap<u32, CoreMarketSpecification>) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,10 +16,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Load configuration
     let mut config = VexConfig::load_auto()?;
 
-    config.core_networking.local_address = "0.0.0.0".to_string();
-    config.core_networking.context_dir = "/dev/shm/aeron".to_string();
-    config.kafka_broker =
-        std::env::var("KAFKA_BROKER").unwrap_or_else(|_| "localhost:9092".to_string());
+    apply_container_networking_overrides(&mut config);
 
     if let Ok(pinning_str) = std::env::var("ENABLE_CORE_PINNING") {
         if let Ok(pinning_value) = pinning_str.parse::<bool>() {
@@ -104,4 +101,28 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     engine.join()?;
 
     Ok(())
+}
+
+fn apply_container_networking_overrides(config: &mut VexConfig) {
+    config.core_networking.local_address = "0.0.0.0".to_string();
+    config.core_networking.context_dir = "/dev/shm/aeron".to_string();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    // #166 removed the crate-level Environment import; #180's tests still need it.
+    use vex_config::Environment;
+
+    #[test]
+    fn container_networking_overrides_preserve_configured_kafka_broker() {
+        let mut config = VexConfig::new(Environment::Development);
+        config.kafka_broker = "configured-kafka:19092".to_string();
+
+        apply_container_networking_overrides(&mut config);
+
+        assert_eq!(config.kafka_broker, "configured-kafka:19092");
+        assert_eq!(config.core_networking.local_address, "0.0.0.0");
+        assert_eq!(config.core_networking.context_dir, "/dev/shm/aeron");
+    }
 }

--- a/vex-config/src/lib.rs
+++ b/vex-config/src/lib.rs
@@ -118,7 +118,7 @@ impl VexConfig {
 
     /// Validate the entire configuration
     pub fn validate(&self) -> Result<()> {
-        self.core_networking.validate()?;
+        self.core_networking.validate(&self.environment)?;
         self.gateway_networking.validate()?;
         self.logging.validate()?;
         self.symbols.validate()?;
@@ -129,6 +129,11 @@ impl VexConfig {
         }
         #[cfg(feature = "balance-preload")]
         if self.balance_preload.enabled {
+            if self.is_production() {
+                return Err(ConfigError::ValidationError(
+                    "Balance preload cannot be enabled in production".to_string(),
+                ));
+            }
             self.balance_preload.validate()?;
         }
         Ok(())

--- a/vex-config/src/networking.rs
+++ b/vex-config/src/networking.rs
@@ -127,7 +127,7 @@ impl CoreNetworkingConfig {
     }
 
     /// Validate the configuration
-    pub fn validate(&self) -> Result<()> {
+    pub fn validate(&self, environment: &Environment) -> Result<()> {
         if self.initial_port == 0 {
             return Err(ConfigError::network("Initial port cannot be 0"));
         }
@@ -162,6 +162,12 @@ impl CoreNetworkingConfig {
 
         if self.context_dir.is_empty() {
             return Err(ConfigError::network("Context directory cannot be empty"));
+        }
+
+        if environment.is_production() && self.request_control_channel.is_empty() {
+            return Err(ConfigError::network(
+                "Archive request control channel cannot be empty in production",
+            ));
         }
 
         Ok(())
@@ -345,14 +351,24 @@ mod tests {
     #[test]
     fn test_core_networking_validation() {
         let mut config = CoreNetworkingConfig::development_defaults();
-        assert!(config.validate().is_ok());
+        assert!(config.validate(&Environment::Development).is_ok());
 
         config.initial_port = 0;
-        assert!(config.validate().is_err());
+        assert!(config.validate(&Environment::Development).is_err());
 
         config.initial_port = 8080;
         config.initial_control_port = 8080;
-        assert!(config.validate().is_err());
+        assert!(config.validate(&Environment::Development).is_err());
+    }
+
+    #[test]
+    fn empty_archive_channel_is_only_valid_outside_production() {
+        let mut config = CoreNetworkingConfig::development_defaults();
+        config.request_control_channel.clear();
+
+        assert!(config.validate(&Environment::Development).is_ok());
+        assert!(config.validate(&Environment::Test).is_ok());
+        assert!(config.validate(&Environment::Production).is_err());
     }
 
     #[test]

--- a/vex-config/tests/integration_tests.rs
+++ b/vex-config/tests/integration_tests.rs
@@ -72,6 +72,18 @@ fn test_configuration_validation() {
     assert!(config.validate().is_err());
 }
 
+#[cfg(feature = "balance-preload")]
+#[test]
+fn production_configuration_rejects_balance_preload() {
+    let mut production = VexConfig::new(Environment::Production);
+    production.balance_preload.enabled = true;
+    assert!(production.validate().is_err());
+
+    let mut development = VexConfig::new(Environment::Development);
+    development.balance_preload.enabled = true;
+    assert!(development.validate().is_ok());
+}
+
 #[test]
 fn test_file_loading_and_saving() -> Result<(), Box<dyn std::error::Error>> {
     let temp_dir = TempDir::new()?;


### PR DESCRIPTION
Three grouped balance-preload and configuration findings.

## 1. `balance-preload` had no environment gate — **fixed**

The feature deposits balances at startup, **before the archive publication exists**, so preloaded
balances were never journaled and vanished on replay — the exchange would come back with different
balances than it shut down with. And a cargo feature is a **build-time** choice, not a deployment
guard: a binary built with it preloads in production.

`validate()` now rejects `balance_preload` in a production environment, and the server validates
before initialisation so the deposits never execute there.

Fail-fast rather than making the deposits journaled: preloading balances is a development and test
affordance, and the right answer in production is that it does not happen at all, not that it happens
durably.

## 2. Configuration overwritten in `main.rs` — **partially fixed, deliberately**

`kafka_broker` was discarded in favour of a `KAFKA_BROKER` environment variable that nothing else in
the repository sets, so the configured value could never take effect. The configured value is now
honoured and the ad-hoc override is removed.

**Two overwrites are kept on purpose**, and this is the part worth reviewing:

- `context_dir = "/dev/shm/aeron"` — the shipped compose deployment shares exactly that path with the
  media-driver container. Honouring a different configured value would break it. (See #130 / PR #165,
  where this path alignment is what makes the health check work at all.)
- `local_address = "0.0.0.0"` — a container has to bind an address reachable from outside itself.
  Narrowing it needs to be designed against the deployment, and doing it here would ship a gateway
  that cannot connect.

Both are real findings; neither is safe to fix without also changing the deployment, so they stay
until that is done together.

## 3. An empty `request_control_channel` silently disabled journaling — **fixed**

The exchange could run with **no journal at all** and look completely healthy. `validate()` never
checked it.

Journaling being optional is a supported mode — `networking/src/server/mod.rs:133` logs
`archive_recording = false` as a normal startup, and #116 / PR #159 deliberately relies on that
staying true. So the fix is not to make it fatal everywhere; it is to make it **deliberate and
visible**:

- `validate()` rejects an empty `request_control_channel` in production.
- A non-production startup emits an **ERROR-level** `journaling_disabled` event saying replay is
  impossible.

An operator should never discover there was no journal during a post-incident investigation.

`cargo test -p vex-server -p vex-config`: 43 passed, 0 failed, plus 2 feature-specific
balance-preload tests. clippy: 0 warnings, including with the feature enabled.

## Related

Closes #144

- vex-core #134 / PR #166 — the sibling defect: a config load failure silently becoming zero-fee
  Test defaults.
- vex-core #116 / PR #159 — archive durability, which depends on journaling-optional remaining a
  supported mode.
- vex-core #130 / PR #165 — the compose deployment that item 2's kept overwrites serve.
