### PR TITLE
test: one pipeline construction, real fee assertions, honest invariant checks, both CI feature sets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,9 @@ jobs:
           RUSTFLAGS: "-D warnings -C link-arg=-fuse-ld=mold"
 
       - name: Run tests
-        run: cargo test --workspace --all-features --all-targets
+        run: |
+          cargo test --workspace --all-targets
+          cargo test --workspace --all-features --all-targets
         env:
           RUSTFLAGS: "-D warnings -C link-arg=-fuse-ld=mold"
           VEX_KAFKA_BROKER: localhost:9092

--- a/processors/src/risk_engine.rs
+++ b/processors/src/risk_engine.rs
@@ -353,7 +353,7 @@ impl RiskEngine {
         // PR #178 made get_balance_mut fallible so a REJECTED operation can no longer insert
         // an empty row. This is the commit point: every validation above has passed, so the
         // write must succeed even for an asset the user is receiving for the first time.
-        // set_balance inserts-or-updates, keeping PR #153's all-or-nothing commit intact.
+        // set_balance inserts-or-updates, which keeps #153's all-or-nothing commit intact.
         if asset_to_add == asset_to_subtract {
             store.set_balance(user_id, asset_to_add, balance_add);
         } else {
@@ -1182,7 +1182,7 @@ mod tests {
         // collateral record is deliberately NOT an error (see
         // test_bid_cancel_without_collateral_record_is_safe). The ASK path still unlocks base
         // directly, so it is the case that genuinely fails and must surface as Rejected --
-        // which is the guarantee PR #178 is about.
+        // which is what PR #178's guarantee is about.
         let mut cmd =
             OrderCommand::place_order(TimeInForce::Gtc, user_id, 100, 10, Side::Ask, market_id, 1);
         cmd.set_status(Status::Cancelled);

--- a/server/src/engine.rs
+++ b/server/src/engine.rs
@@ -654,7 +654,6 @@ pub mod test {
         matching_engines: [usize; NUM_MATCHING_ENGINES],
         risk_r2_engines: [usize; NUM_RISK_ENGINES],
         events: usize,
-        test_handler: usize,
     }
 
     impl Default for TestCorePinning {
@@ -665,7 +664,6 @@ pub mod test {
                 matching_engines: [6, 7, 8, 9],
                 risk_r2_engines: [10, 11, 12, 13],
                 events: 14,
-                test_handler: 15,
             }
         }
     }
@@ -701,23 +699,16 @@ pub mod test {
                 journaling_processor: None,
                 events_handler: None,
                 publications: None,
-                core_pinning: Some(TestCorePinning {
-                    journaling: 1,
-                    risk_engines: [2, 3, 4, 5],
-                    matching_engines: [6, 7, 8, 9],
-                    risk_r2_engines: [10, 11, 12, 13],
-                    events: 14,
-                    test_handler: 15,
-                }),
+                core_pinning: None,
                 test_handler: None,
                 risk_engines: None,
             }
         }
 
-        /// Disables CPU pinning for this test (useful for environments without enough cores)
+        /// Enables CPU pinning for this test
         #[must_use]
-        pub fn without_cpu_pinning(mut self) -> Self {
-            self.core_pinning = None;
+        pub fn with_cpu_pinning(mut self, pinning: TestCorePinning) -> Self {
+            self.core_pinning = Some(pinning);
             self
         }
 
@@ -859,247 +850,41 @@ pub mod test {
 
             let mut router_handlers_iter = router_handlers.into_iter();
 
+            let mut test_handler = test_handler;
             let events_handler =
-                move |cell: &UnsafeCell<OrderCommand>, _sequence: i64, _end_of_batch: bool| {
-                    // SAFETY: The test events handler is the sole handler in this barrier
-                    // group, so creating this exclusive reference cannot alias another
-                    // handler's reference.
-                    let cmd = unsafe { &mut *cell.get() };
-                    events_handler.handle_processed_command(cmd);
+                move |cell: &UnsafeCell<OrderCommand>, sequence: i64, end_of_batch: bool| {
+                    {
+                        // SAFETY: The test events handler is the sole handler in this barrier
+                        // group, so creating this exclusive reference cannot alias another
+                        // handler's reference.
+                        let cmd = unsafe { &mut *cell.get() };
+                        events_handler.handle_processed_command(cmd);
+                    }
+                    // PR #181 runs the test handler inline; PR #184 gives it the cell ABI.
+                    if let Some(handler) = test_handler.as_mut() {
+                        handler(cell, sequence, end_of_batch);
+                    }
                 };
 
-            let producer = if let Some(test_handler) = test_handler {
-                if let Some(pinning) = core_pinning {
-                    self.build_test_pipeline(
-                        BUFFER_SIZE,
-                        order_factory,
-                        journaling_handler,
-                        &risk_engines_arc,
-                        &price_cache,
-                        &mut router_handlers_iter,
-                        events_handler,
-                        test_handler,
-                        pinning,
-                        false, // Tests don't use pinning
-                    )
-                } else {
-                    self.build_test_pipeline(
-                        BUFFER_SIZE,
-                        order_factory,
-                        journaling_handler,
-                        &risk_engines_arc,
-                        &price_cache,
-                        &mut router_handlers_iter,
-                        events_handler,
-                        test_handler,
-                        TestCorePinning::default(),
-                        false, // Tests don't use pinning
-                    )
-                }
-            } else if let Some(pinning) = core_pinning {
-                CoreEngine::build_disruptor_pipeline(
-                    BUFFER_SIZE,
-                    order_factory,
-                    journaling_handler,
-                    &risk_engines_arc,
-                    &price_cache,
-                    &mut router_handlers_iter,
-                    events_handler,
-                    pinning.into(),
-                    false, // Tests don't use pinning
-                )
-            } else {
-                CoreEngine::build_disruptor_pipeline(
-                    BUFFER_SIZE,
-                    order_factory,
-                    journaling_handler,
-                    &risk_engines_arc,
-                    &price_cache,
-                    &mut router_handlers_iter,
-                    events_handler,
-                    CorePinning::default(),
-                    false, // Tests don't use pinning
-                )
+            let (core_pinning, enable_pinning) = match core_pinning {
+                Some(pinning) => (pinning.into(), true),
+                None => (CorePinning::default(), false),
             };
+
+            let producer = CoreEngine::build_disruptor_pipeline(
+                BUFFER_SIZE,
+                order_factory,
+                journaling_handler,
+                &risk_engines_arc,
+                &price_cache,
+                &mut router_handlers_iter,
+                events_handler,
+                core_pinning,
+                enable_pinning,
+            );
 
             let engine = CoreEngine { publications };
             Ok((engine, producer))
-        }
-
-        /// Builds the test-specific disruptor pipeline with test handler
-        #[allow(clippy::too_many_arguments)]
-        fn build_test_pipeline(
-            &self,
-            buffer_size: usize,
-            order_factory: fn() -> OrderCommand,
-            journaling_handler: impl FnMut(&UnsafeCell<OrderCommand>, i64, bool) + Send + 'static,
-            risk_engines: &RiskEngines,
-            price_cache: &Arc<PriceCache>,
-            router_handlers_iter: &mut impl Iterator<
-                Item = impl FnMut(&UnsafeCell<OrderCommand>, i64, bool) + Send + 'static,
-            >,
-            events_handler: impl FnMut(&UnsafeCell<OrderCommand>, i64, bool) + Send + 'static,
-            test_handler: TestHandler,
-            core_pinning: TestCorePinning,
-            enable_pinning: bool,
-        ) -> OrderProducer {
-            info!(
-                target: "engine::test",
-                action = "building_test_pipeline",
-                enable_pinning,
-                "Building test disruptor pipeline with pinning: {}", enable_pinning
-            );
-
-            // Stage 1: Journaling
-            let pipeline = build_multi_producer(buffer_size, order_factory, BusySpin);
-            let pipeline = if enable_pinning {
-                pipeline.pin_at_core(core_pinning.journaling)
-            } else {
-                pipeline
-            };
-            let pipeline = pipeline
-                .handle_events_with(abort_on_handler_panic("journaling", journaling_handler));
-
-            // Dependency barrier: risk engines wait for journaling
-            let pipeline = pipeline.and_then();
-
-            // Stage 2: Risk Engine R1
-            let pipeline = if enable_pinning {
-                pipeline.pin_at_core(core_pinning.risk_engines[0])
-            } else {
-                pipeline
-            };
-            let pipeline = pipeline.handle_events_with(abort_on_handler_panic(
-                "risk_r1_0",
-                create_risk_handler!(0, risk_engines, price_cache),
-            ));
-            let pipeline = if enable_pinning {
-                pipeline.pin_at_core(core_pinning.risk_engines[1])
-            } else {
-                pipeline
-            };
-            let pipeline = pipeline.handle_events_with(abort_on_handler_panic(
-                "risk_r1_1",
-                create_risk_handler!(1, risk_engines, price_cache),
-            ));
-            let pipeline = if enable_pinning {
-                pipeline.pin_at_core(core_pinning.risk_engines[2])
-            } else {
-                pipeline
-            };
-            let pipeline = pipeline.handle_events_with(abort_on_handler_panic(
-                "risk_r1_2",
-                create_risk_handler!(2, risk_engines, price_cache),
-            ));
-            let pipeline = if enable_pinning {
-                pipeline.pin_at_core(core_pinning.risk_engines[3])
-            } else {
-                pipeline
-            };
-            let pipeline = pipeline.handle_events_with(abort_on_handler_panic(
-                "risk_r1_3",
-                create_risk_handler!(3, risk_engines, price_cache),
-            ));
-            let pipeline = pipeline.and_then();
-
-            // Stage 3: Matching Engine
-            let pipeline = if enable_pinning {
-                pipeline.pin_at_core(core_pinning.matching_engines[0])
-            } else {
-                pipeline
-            };
-            let pipeline = pipeline.handle_events_with(abort_on_handler_panic(
-                "matching_0",
-                router_handlers_iter.next().expect("Missing router handler"),
-            ));
-            let pipeline = if enable_pinning {
-                pipeline.pin_at_core(core_pinning.matching_engines[1])
-            } else {
-                pipeline
-            };
-            let pipeline = pipeline.handle_events_with(abort_on_handler_panic(
-                "matching_1",
-                router_handlers_iter.next().expect("Missing router handler"),
-            ));
-            let pipeline = if enable_pinning {
-                pipeline.pin_at_core(core_pinning.matching_engines[2])
-            } else {
-                pipeline
-            };
-            let pipeline = pipeline.handle_events_with(abort_on_handler_panic(
-                "matching_2",
-                router_handlers_iter.next().expect("Missing router handler"),
-            ));
-            let pipeline = if enable_pinning {
-                pipeline.pin_at_core(core_pinning.matching_engines[3])
-            } else {
-                pipeline
-            };
-            let pipeline = pipeline.handle_events_with(abort_on_handler_panic(
-                "matching_3",
-                router_handlers_iter.next().expect("Missing router handler"),
-            ));
-            let pipeline = pipeline.and_then();
-
-            // Stage 4: Risk Engine R2
-            let pipeline = if enable_pinning {
-                pipeline.pin_at_core(core_pinning.risk_r2_engines[0])
-            } else {
-                pipeline
-            };
-            let pipeline = pipeline.handle_events_with(abort_on_handler_panic(
-                "risk_r2_0",
-                create_risk_r2_handler!(0, risk_engines),
-            ));
-            let pipeline = if enable_pinning {
-                pipeline.pin_at_core(core_pinning.risk_r2_engines[1])
-            } else {
-                pipeline
-            };
-            let pipeline = pipeline.handle_events_with(abort_on_handler_panic(
-                "risk_r2_1",
-                create_risk_r2_handler!(1, risk_engines),
-            ));
-            let pipeline = if enable_pinning {
-                pipeline.pin_at_core(core_pinning.risk_r2_engines[2])
-            } else {
-                pipeline
-            };
-            let pipeline = pipeline.handle_events_with(abort_on_handler_panic(
-                "risk_r2_2",
-                create_risk_r2_handler!(2, risk_engines),
-            ));
-            let pipeline = if enable_pinning {
-                pipeline.pin_at_core(core_pinning.risk_r2_engines[3])
-            } else {
-                pipeline
-            };
-            let pipeline = pipeline.handle_events_with(abort_on_handler_panic(
-                "risk_r2_3",
-                create_risk_r2_handler!(3, risk_engines),
-            ));
-            let pipeline = pipeline.and_then();
-
-            // Stage 5: Event Handlers
-            let pipeline = if enable_pinning {
-                pipeline.pin_at_core(core_pinning.events)
-            } else {
-                pipeline
-            };
-            let pipeline =
-                pipeline.handle_events_with(abort_on_handler_panic("events", events_handler));
-            let pipeline = pipeline.and_then();
-
-            // Test Handler
-            let pipeline = if enable_pinning {
-                pipeline.pin_at_core(core_pinning.test_handler)
-            } else {
-                pipeline
-            };
-            let pipeline =
-                pipeline.handle_events_with(abort_on_handler_panic("test", test_handler));
-
-            pipeline.build()
         }
     }
 
@@ -1152,5 +937,10 @@ pub mod test {
             String::from_utf8_lossy(&child.stderr).contains("test_stage"),
             "panic log must identify the failed stage"
         );
+    }
+
+    #[test]
+    fn test_engine_builder_does_not_pin_by_default() {
+        assert!(TestEngineBuilder::new().core_pinning.is_none());
     }
 }

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -285,16 +285,7 @@ pub mod test {
                 .collect::<Vec<_>>(),
         );
 
-        // Check VEX_ENV to determine if CPU pinning should be disabled
-        let mut builder = TestEngineBuilder::new();
-        if matches!(
-            std::env::var("VEX_ENV"),
-            Ok(env) if env.to_lowercase() == "dev" || env.to_lowercase() == "development"
-        ) {
-            builder = builder.without_cpu_pinning();
-        }
-
-        let (_engine, producer) = builder
+        let (_engine, producer) = TestEngineBuilder::new()
             .with_symbol_specs(specs)
             .with_journaling_processor(JournalingProcessor::new(
                 Arc::clone(&publications),
@@ -977,6 +968,9 @@ mod tests {
         let quote_asset_id = 2;
         let market_id = ((quote_asset_id as u32) << 16) | (base_asset_id as u32);
         add_spec(market_id, &mut specs);
+        let spec = specs.get_mut(&market_id).unwrap();
+        spec.base_scale_k = 100_000;
+        spec.quote_scale_k = 10;
 
         let (mut producer, risk_engines, rx) = setup_tuple(specs);
         let shard_mask = risk_engines.len() as u64 - 1;
@@ -990,7 +984,7 @@ mod tests {
 
         // 3. Pre-fund accounts
         // Taker (buyer, BID) needs QUOTE asset to buy the BASE asset.
-        let taker_initial_quote = order_price * order_size;
+        let taker_initial_quote = 5_000_000;
         let taker_shard_id = (taker_id & shard_mask) as usize;
         risk_engines[taker_shard_id].set_balance(
             taker_id,
@@ -1059,13 +1053,10 @@ mod tests {
             .expect("Taker command should have a trade event");
 
         // --- Taker (Buyer, BID) Balance Verification ---
-        // Spends `price * size` of quote. Receives `size` of base, minus taker fee (20bp on base).
-        let taker_fee_in_base = (order_size * 20) / 10000;
-        let net_base_received = order_size - taker_fee_in_base;
-
+        // Spends 5,000,000 scaled quote units. Receives 10,000 base units minus a 20-unit fee.
         assert_eq!(
             taker_filled_cmd.balance[0].total(), // base asset
-            net_base_received,
+            9_980,
             "Taker's base balance is incorrect"
         );
         assert_eq!(
@@ -1083,11 +1074,7 @@ mod tests {
         );
 
         // --- Maker (Seller, ASK) Balance Verification ---
-        // Spends `size` of base. Receives `price * size` of quote, minus maker fee (10bp on quote).
-        let gross_quote_received = order_price * order_size;
-        let maker_fee_in_quote = (gross_quote_received * 10) / 10000;
-        let net_quote_received = gross_quote_received - maker_fee_in_quote;
-
+        // Spends 10,000 base units. Receives 5,000,000 scaled quote units minus a 5,000-unit fee.
         assert_eq!(
             trade_event.maker_balance[0].total(), // base asset
             0,
@@ -1095,7 +1082,7 @@ mod tests {
         );
         assert_eq!(
             trade_event.maker_balance[1].total(),
-            net_quote_received,
+            4_995_000,
             "Maker's quote balance is incorrect"
         );
         assert_eq!(
@@ -1222,10 +1209,7 @@ mod tests {
             .recv_timeout(Duration::from_secs(5))
             .expect("Did not receive taker's filled command");
         // balances should be updated correctly for both taker and makers
-        assert_eq!(
-            taker_filled_cmd.balance[0].total(),
-            taker_trade_size - (taker_trade_size * 20 / 10000)
-        ); // base after 20bp fee
+        assert_eq!(taker_filled_cmd.balance[0].total(), 44_910); // base after 20bp fee
         assert_eq!(taker_filled_cmd.balance[1].total(), 0);
         // no balance must be locked for the taker after the trade
         assert_eq!(taker_filled_cmd.balance[1].locked, 0);
@@ -1247,9 +1231,7 @@ mod tests {
         assert!(event1.matched_order_completed);
         assert!(!event1.active_order_completed);
         assert_eq!(event1.maker_balance[0].available(), 0); // Maker 1 sold all base
-        let expected_maker1_quote =
-            (order_price * maker1_size) - (order_price * maker1_size * 10 / 10000); // 10bp fee
-        assert_eq!(event1.maker_balance[1].available(), expected_maker1_quote);
+        assert_eq!(event1.maker_balance[1].available(), 49_950_000);
         assert_eq!(event1.maker_balance[1].locked, 0);
         assert_eq!(event1.maker_balance[0].locked, 0);
         assert_eq!(
@@ -1269,9 +1251,7 @@ mod tests {
         assert!(event2.matched_order_completed);
         assert!(!event2.active_order_completed);
         assert_eq!(event2.maker_balance[0].available(), 0); // Maker
-        let expected_maker2_quote =
-            (order_price * maker2_size) - (order_price * maker2_size * 10 / 10000); // 10bp fee
-        assert_eq!(event2.maker_balance[1].available(), expected_maker2_quote);
+        assert_eq!(event2.maker_balance[1].available(), 99_900_000);
         assert_eq!(event2.maker_balance[1].locked, 0);
         assert_eq!(event2.maker_balance[0].locked, 0);
         assert_eq!(
@@ -1302,9 +1282,7 @@ mod tests {
             maker3_size - maker3_trade_size
         ); // Maker 3 partially sold
         assert_eq!(event3.maker_balance[0].available(), 0); // the rest is in locked
-        let expected_maker3_quote =
-            (order_price * maker3_trade_size) - (order_price * maker3_trade_size * 10 / 10000); // 10bp fee
-        assert_eq!(event3.maker_balance[1].available(), expected_maker3_quote);
+        assert_eq!(event3.maker_balance[1].available(), 74_925_000);
         assert_eq!(event3.maker_balance[1].locked(), 0);
         assert_eq!(
             risk_engines[maker3_shard].get_balance(maker3_id, base_asset_id),
@@ -1317,26 +1295,14 @@ mod tests {
         assert!(event3.next_event.is_none(), "There should be only 3 events");
 
         // --- Verify Maker Balances from Events and Risk Engine State ---
-        let maker_fee_rate = 10; // 0.1% on quote asset
-        for (event, maker_id, maker_shard, initial_size) in [
-            (event1, maker1_id, maker1_shard, maker1_size),
-            (event2, maker2_id, maker2_shard, maker2_size),
-            (event3, maker3_id, maker3_shard, maker3_size),
+        for (event, maker_id, maker_shard, expected_base_locked, expected_quote) in [
+            (event1, maker1_id, maker1_shard, 0, 49_950_000),
+            (event2, maker2_id, maker2_shard, 0, 99_900_000),
+            (event3, maker3_id, maker3_shard, 15_000, 74_925_000),
         ] {
-            let trade_size = event.size;
-            let quote_recv = order_price * trade_size;
-            let fee = (quote_recv * maker_fee_rate) / 10000;
-            let net_quote_recv = quote_recv - fee;
-
-            let (final_base_avail, final_base_locked) = if event.matched_order_completed {
-                (0, 0)
-            } else {
-                (0, initial_size - trade_size)
-            };
-
-            assert_eq!(event.maker_balance[0].available, final_base_avail);
-            assert_eq!(event.maker_balance[0].locked, final_base_locked);
-            assert_eq!(event.maker_balance[1].available, net_quote_recv);
+            assert_eq!(event.maker_balance[0].available, 0);
+            assert_eq!(event.maker_balance[0].locked, expected_base_locked);
+            assert_eq!(event.maker_balance[1].available, expected_quote);
             assert_eq!(event.maker_balance[1].locked, 0);
 
             assert_eq!(
@@ -1350,13 +1316,9 @@ mod tests {
         }
 
         // --- Final Taker Balance Verification ---
-        let total_base_received = taker_trade_size;
-        let taker_fee = (total_base_received * 20) / 10000; // 0.2% on base
-        let net_base_received = total_base_received - taker_fee;
-
         assert_eq!(
             taker_filled_cmd.balance[0].total(), // base
-            net_base_received,
+            44_910,
             "Taker's base balance is incorrect"
         );
         assert_eq!(
@@ -1457,14 +1419,12 @@ mod tests {
 
         // --- Verify Balances ---
         // Taker (Buyer, BID)
-        let taker_fee_in_base = (maker_ask_size * 20) / 10000; // 0.2% on base
-        let taker_net_base_received = maker_ask_size - taker_fee_in_base;
         let taker_quote_spent = maker_ask_price * maker_ask_size;
 
         let taker_final_base = risk_engines[taker_shard].get_balance(taker_id, base_asset_id);
         let taker_final_quote = risk_engines[taker_shard].get_balance(taker_id, quote_asset_id);
 
-        assert_eq!(taker_final_base.total(), taker_net_base_received);
+        assert_eq!(taker_final_base.total(), 4_990);
         assert_eq!(
             taker_final_quote.total(),
             taker_initial_quote - taker_quote_spent
@@ -1475,15 +1435,11 @@ mod tests {
         );
 
         // Maker (Seller, ASK)
-        let maker_gross_quote_received = maker_ask_price * maker_ask_size;
-        let maker_fee_in_quote = (maker_gross_quote_received * 10) / 10000; // 0.1% on quote
-        let maker_net_quote_received = maker_gross_quote_received - maker_fee_in_quote;
-
         let maker_final_base = risk_engines[maker_shard].get_balance(maker_id, base_asset_id);
         let maker_final_quote = risk_engines[maker_shard].get_balance(maker_id, quote_asset_id);
 
         assert_eq!(maker_final_base.total(), 0);
-        assert_eq!(maker_final_quote.total(), maker_net_quote_received);
+        assert_eq!(maker_final_quote.total(), 249_750_000);
     }
 
     #[test]
@@ -1900,6 +1856,7 @@ mod tests {
         );
         assert_eq!(
             risk_engines[maker_a_shard].get_balance(maker_a_id, quote_asset_id),
+            // 10_090 pre-#163 (floor fee 10); #163's div_ceil makes the 10 bp fee 11.
             UserBalance::new(maker_a_quote_recv - maker_a_fee, 0)
         );
 
@@ -1912,6 +1869,7 @@ mod tests {
         );
         assert_eq!(
             risk_engines[maker_b_shard].get_balance(maker_b_id, quote_asset_id),
+            // 15_285 pre-#163 (floor fee 15); #163's div_ceil makes it 16.
             UserBalance::new(maker_b_quote_recv - maker_b_fee, 0)
         );
 
@@ -1921,6 +1879,7 @@ mod tests {
         let maker_c_fee = (maker_c_quote_recv * 10).div_ceil(10000); // 10bp on quote
         assert_eq!(
             risk_engines[maker_c_shard].get_balance(maker_c_id, quote_asset_id),
+            // 5_095 pre-#163 (floor fee 5); #163's div_ceil makes it 6.
             UserBalance::new(maker_c_quote_recv - maker_c_fee, 0)
         );
         assert_eq!(
@@ -2207,31 +2166,27 @@ mod tests {
         );
 
         // Check balances post-IOC. Charlie's locked USD for the unfilled 5000 ETH should be free.
-        let charlie_eth_cost = 20000 * 3000;
-        let charlie_eth_fee = (20000 * 20) / 10000; // Taker fee is on base (ETH)
         checker.check(
             charlie_fok_ioc_id,
             usd_asset,
-            100_000_000 - charlie_eth_cost,
+            40_000_000,
             0,
             "Charlie's USD spent on ETH",
         );
         checker.check(
             charlie_fok_ioc_id,
             eth_asset,
-            20000 - charlie_eth_fee,
+            19_960,
             0,
             "Charlie received ETH minus taker fee",
         );
 
         // Alice's ETH ask was fully filled
-        let alice_usd_gain = charlie_eth_cost;
-        let alice_usd_fee = (alice_usd_gain * 10) / 10000; // Maker fee is on quote (USD)
         checker.check(alice_mm_id, eth_asset, 30000, 0, "Alice's ETH ask is gone");
         checker.check(
             alice_mm_id,
             usd_asset,
-            100_000_000 - (1000 * 49900) + (alice_usd_gain - alice_usd_fee),
+            110_040_000,
             1000 * 49900,
             "Alice received USD minus maker fee",
         );
@@ -2293,25 +2248,22 @@ mod tests {
         );
 
         // Check balances after successful FOK
-        let bob_btc_cost = 40000 * 30;
-        let bob_sol_fee = (40000 * 20) / 10000;
+        let bob_btc_cost = 1_200_000;
         checker.check(
             bob_taker_id,
             btc_asset,
-            5_000_000 - bob_btc_cost,
+            3_800_000,
             0,
             "Bob spent BTC on SOL",
         );
         checker.check(
             bob_taker_id,
             sol_asset,
-            40000 - bob_sol_fee,
+            39_920,
             0,
             "Bob received SOL minus fee",
         );
 
-        let david_btc_gain = bob_btc_cost;
-        let david_btc_fee = (david_btc_gain * 10) / 10000;
         checker.check(
             david_sol_mm_id,
             sol_asset,
@@ -2322,7 +2274,7 @@ mod tests {
         checker.check(
             david_sol_mm_id,
             btc_asset,
-            5_000_000 - (50000 * 29) + (david_btc_gain - david_btc_fee),
+            4_748_800,
             50000 * 29,
             "David received BTC for SOL minus fee",
         );

--- a/xtask/src/verifiers/invariants.rs
+++ b/xtask/src/verifiers/invariants.rs
@@ -10,11 +10,22 @@ use tracing::debug;
 /// Verifier for system-wide invariants
 ///
 /// These invariants are fundamental properties that must always hold true:
-/// - Balance consistency: available + locked = total
-/// - Balance conservation: total system balance = deposits - withdrawals - fees
-/// - Trade-balance coupling: every trade has corresponding balance updates
-/// - Orderbook consistency: snapshot matches active orders
+/// - Balance consistency and overflow safety
+/// - Orderbook price ordering and non-crossing
+/// - Trade timestamp ordering, positive sizes, and valid prices
 pub struct InvariantVerifier;
+
+fn checked_balance_total(balance: &RedisBalance) -> TestResult<u64> {
+    balance
+        .available
+        .checked_add(balance.locked)
+        .ok_or_else(|| TestError::Verification {
+            message: format!(
+                "Balance overflow detected for user {} asset {}: available={} + locked={}",
+                balance.user_id, balance.asset_id, balance.available, balance.locked
+            ),
+        })
+}
 
 impl InvariantVerifier {
     /// Verify balance invariant for all specified users and assets
@@ -29,11 +40,19 @@ impl InvariantVerifier {
             for &asset_id in assets {
                 match redis.get_balance(user_id, asset_id).await {
                     Ok(balance) => {
-                        balance
-                            .verify_invariant()
-                            .map_err(|e| TestError::Verification {
-                                message: format!("Balance invariant violated: {}", e),
-                            })?;
+                        let computed_total = checked_balance_total(&balance)?;
+                        if computed_total != balance.total {
+                            return Err(TestError::Verification {
+                                message: format!(
+                                    "Balance invariant violated for user {} asset {}: available({}) + locked({}) != total({})",
+                                    user_id,
+                                    asset_id,
+                                    balance.available,
+                                    balance.locked,
+                                    balance.total
+                                ),
+                            });
+                        }
                     }
                     Err(TestError::Verification { .. }) => {
                         // Balance not found, skip (user may not have this asset)
@@ -53,10 +72,11 @@ impl InvariantVerifier {
         Ok(())
     }
 
-    /// Verify that no balance is negative
+    /// Verify that adding unsigned balance components cannot overflow
     ///
-    /// This is a critical safety invariant - users should never have negative balances.
-    pub async fn verify_no_negative_balances(
+    /// Redis balances are unsigned, so negative values cannot be represented. This check detects
+    /// values whose `available + locked` sum would wrap around.
+    pub async fn verify_no_balance_overflow(
         redis: &mut RedisVerifier,
         users: &[u64],
         assets: &[u16],
@@ -65,23 +85,7 @@ impl InvariantVerifier {
             for &asset_id in assets {
                 match redis.get_balance(user_id, asset_id).await {
                     Ok(balance) => {
-                        // Balances are u64, but we check for wraparound indicators
-                        if balance.available > balance.total {
-                            return Err(TestError::Verification {
-                                message: format!(
-                                    "Balance wraparound detected for user {} asset {}: available={} > total={}",
-                                    user_id, asset_id, balance.available, balance.total
-                                ),
-                            });
-                        }
-                        if balance.locked > balance.total {
-                            return Err(TestError::Verification {
-                                message: format!(
-                                    "Balance wraparound detected for user {} asset {}: locked={} > total={}",
-                                    user_id, asset_id, balance.locked, balance.total
-                                ),
-                            });
-                        }
+                        checked_balance_total(&balance)?;
                     }
                     Err(TestError::Verification { .. }) => {
                         // Balance not found, skip
@@ -93,7 +97,7 @@ impl InvariantVerifier {
         }
 
         debug!(
-            "No negative balances found for {} users and {} assets",
+            "Balance arithmetic verified for {} users and {} assets",
             users.len(),
             assets.len()
         );
@@ -268,7 +272,7 @@ impl InvariantVerifier {
 
         // Balance invariants
         Self::verify_balance_consistency(redis, users, assets).await?;
-        Self::verify_no_negative_balances(redis, users, assets).await?;
+        Self::verify_no_balance_overflow(redis, users, assets).await?;
 
         // Orderbook invariants
         match Self::verify_orderbook_ordering(redis, market_id).await {
@@ -302,5 +306,35 @@ impl InvariantVerifier {
         debug!("All invariants verified successfully");
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn balance(available: u64, locked: u64) -> RedisBalance {
+        RedisBalance {
+            user_id: 7,
+            asset_id: 3,
+            available,
+            locked,
+            total: available.saturating_add(locked),
+            timestamp: 0,
+        }
+    }
+
+    #[test]
+    fn checked_balance_total_accepts_maximum_non_overflowing_sum() {
+        assert_eq!(
+            checked_balance_total(&balance(u64::MAX - 1, 1)).unwrap(),
+            u64::MAX
+        );
+    }
+
+    #[test]
+    fn checked_balance_total_rejects_overflow() {
+        let error = checked_balance_total(&balance(u64::MAX, 1)).unwrap_err();
+        assert!(error.to_string().contains("Balance overflow detected"));
     }
 }


### PR DESCRIPTION
Five grouped test-suite and build findings. Four fixed, one declined with reasons.

## 1. The disruptor pipeline was transcribed twice — **fixed**

`build_disruptor_pipeline` and `build_test_pipeline` were two hand-maintained copies of the same
14-stage construction, with nothing keeping them in sync.

There is now **one** construction. The test path joins it by attaching an observer to the final
handler, and pinning is honoured: present means enabled, absent means disabled. The two copies can no
longer drift, because there is only one.

The first cut of this unification got the default wrong, and the correction is worth stating plainly
because this description originally asserted the opposite. Every test call site passed
`false, // Tests don't use pinning` as `enable_pinning`, which was read here as the test-pinning API
having rotted into dead code that "could never have caught a pinning regression". It was dead — but
that hard-coded `false` was also the only thing keeping tests off specific cores. Collapsing the call
sites into `Some(pinning) => (pinning.into(), true)` while `TestEngineBuilder::new()` still defaulted
`core_pinning` to `Some(TestCorePinning { journaling: 1, risk_engines: [2, 3, 4, 5],
matching_engines: [6, 7, 8, 9], risk_r2_engines: [10, 11, 12, 13], events: 14 })` turned an explicit
opt-out into an on-by-default. Every test then tried to pin to cores 1-14, and on any host that does
not have them the disruptor's `cpu_has_core_else_panic` (`affinity.rs:9`) aborts the run:

```
No core with ID=<n> is available.
```

for the first of cores 1-14 the host lacks.

CI never saw this, which is why it needs calling out rather than quietly fixing. All three test jobs
in `ci.yml` export `VEX_ENV: dev`, and `setup_tuple` carried a `VEX_ENV` branch that called
`without_cpu_pinning()` for `dev`/`development`. `Build and Test` passed on the unification commit
(`vex-server` lib: `7 passed; 0 failed`, under both feature sets) purely because of that env var. The
regression was reachable only from a plain `cargo test` on a machine with fewer than 15 cores.

The default is now `core_pinning: None`, and `without_cpu_pinning()` is replaced by an explicit
`with_cpu_pinning(TestCorePinning)` opt-in — pinning is something a test asks for, not something it
has to remember to decline. The `VEX_ENV` branch in `setup_tuple` goes with it: off by default needs
no escape hatch, and an env var that silently changes thread affinity is worse than an argument.
`test_engine_builder_does_not_pin_by_default` asserts the default so it cannot flip back unnoticed.

## 2. `--all-features` shrank the ring to 256 — **fixed**

`test-config` sets the buffer to 256, and CI ran **only** `--all-features`, so the production buffer
size of 1024 and the pipeline built around it were never executed by any test. A back-pressure or
capacity defect at the real size would not have been caught.

CI now runs both: default features, then `--all-features`. The production configuration is tested.

## 3. Tautological fee assertions — **fixed**

The engine tests computed their expected fee with the **production formula**, so they would have
passed whatever that formula was. Several also evaluated to zero because the sizes were too small,
and the shipped configs use zero fees — so the assertions were both circular and vacuous.

Expected values are now **hand-calculated literals**, at sizes where the fee is non-zero, and a
representative test runs at the shipped `100000/10` scale factors. The tests can now fail.

## 4. An unreachable invariant check with documentation that promised more — **fixed**

`verify_no_negative_balances` compared `available > total`, where `total()` is
`available.saturating_add(locked)` — the condition is **unreachable**, so its "wraparound detection"
detected nothing. Meanwhile the doc comment promised balance conservation and trade-balance coupling,
neither of which existed.

The check now detects a genuine `available + locked` overflow via `checked_add`, and the
documentation says what the verifier actually checks. **The conservation claim is removed rather than
implemented** — conservation needs the fee accumulator added in #118 / PR #173, which is not visible
from this branch. Better an honest short list than a doc comment describing a verifier that does not
exist.

## 5. Commented-out end-to-end tests — **declined, with reasons**

`server/tests/integration_test.rs` is not `#[ignore]`d active code — it is **entirely commented out
and stale**. Un-commenting it does not produce a skipped test; it produces a compile failure, because
it is written against APIs that have since changed. Making it run needs a rewrite against current
APIs plus deterministic shutdown and Aeron media-driver lifecycle management.

That is real work with a real design question attached, not a checkbox, so it is left as it is rather
than half-restored.

## Verification

`cargo test --workspace`: 155 passed, 0 failed. `cargo test --workspace --all-features`: 155 passed,
0 failed. clippy: 0 warnings. Those counts are from the unification commit; the pinning follow-up
adds one test (`test_engine_builder_does_not_pin_by_default`) to each.

Note that a green run is weaker evidence here than it looks, per item 1: run the suite without
`VEX_ENV=dev` set, on a host with fewer than 15 cores, if you want the pinning default exercised.

## Related

Closes #143

- vex-core #118 / PR #173 — the fee accumulator that item 4's conservation check would need.
- vex-core #135 / PR #170 — shipped-scale money tests, the same class of gap as item 3.
- vex-core #136 / PR #167 — core-pinning validation, which item 1's dead test-pinning API should have
  been exercising.
