### PR TITLE
fix: stop event handlers minting aliasing &mut to the same ring slot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,7 @@ dependencies = [
 [[package]]
 name = "disruptor"
 version = "3.6.0"
-source = "git+https://github.com/trade-vex/disruptor-rs.git?rev=19ef2a9#19ef2a9a04de0fb97bc09d852ce5da98396efb57"
+source = "git+https://github.com/trade-vex/disruptor-rs.git?rev=7e07a8b0218d767d021925e58c5ff20fd5c30d70#7e07a8b0218d767d021925e58c5ff20fd5c30d70"
 dependencies = [
  "core_affinity",
  "crossbeam-utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ thiserror = "2.0.12"
 rusteron-client = "=0.1.157"
 rusteron-media-driver = "=0.1.157"
 rusteron-archive = "=0.1.157"
-disruptor = {git="https://github.com/trade-vex/disruptor-rs.git" , rev="19ef2a9"}
+disruptor = {git="https://github.com/trade-vex/disruptor-rs.git" , rev="7e07a8b0218d767d021925e58c5ff20fd5c30d70"}
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tracing = "0.1"

--- a/networking/tests/client_server_tests.rs
+++ b/networking/tests/client_server_tests.rs
@@ -109,14 +109,20 @@ fn test_client_server_communication() {
         )
         .pin_at_core(1)
         .handle_events_with({
-            move |cmd: &mut OrderCommand, _, _| {
+            move |cell: &std::cell::UnsafeCell<OrderCommand>, _, _| {
+                // SAFETY: This test handler is the sole handler in its barrier group, so
+                // creating an exclusive reference cannot alias another handler's reference.
+                let cmd = unsafe { &mut *cell.get() };
                 info!("Server received OrderCommand Core 1: {:?}", cmd);
             }
         })
         .and_then()
         .pin_at_core(2)
         .handle_events_with({
-            move |cmd: &mut OrderCommand, _, _| {
+            move |cell: &std::cell::UnsafeCell<OrderCommand>, _, _| {
+                // SAFETY: This test handler is the sole handler in its barrier group, so
+                // creating an exclusive reference cannot alias another handler's reference.
+                let cmd = unsafe { &mut *cell.get() };
                 info!("Server processing OrderCommand Core 2: {:?}", cmd);
             }
         })

--- a/server/src/engine.rs
+++ b/server/src/engine.rs
@@ -14,6 +14,7 @@ use processors::{
     risk_engine::RiskEngine,
 };
 use std::{
+    cell::UnsafeCell,
     sync::Arc,
     sync::atomic::AtomicBool,
     thread::{self, JoinHandle},
@@ -168,7 +169,11 @@ impl CoreEngine {
         let order_factory = OrderCommand::default;
 
         let journaling_handler =
-            move |cmd: &mut OrderCommand, _sequence: i64, _end_of_batch: bool| {
+            move |cell: &UnsafeCell<OrderCommand>, _sequence: i64, _end_of_batch: bool| {
+                // SAFETY: Journaling is the sole handler in this barrier group, so creating
+                // an exclusive reference to the command cannot alias another handler's
+                // reference.
+                let cmd = unsafe { &mut *cell.get() };
                 journaling_processor.journal_command(cmd);
             };
 
@@ -179,7 +184,16 @@ impl CoreEngine {
 
         let router_handlers = matching_engine_routers.into_iter().map(|mut router| {
             let price_cache_clone = Arc::clone(&price_cache);
-            move |cmd: &mut OrderCommand, _sequence: i64, _end_of_batch: bool| {
+            move |cell: &UnsafeCell<OrderCommand>, _sequence: i64, _end_of_batch: bool| {
+                // SAFETY: This is a shared scalar read; peer matching handlers may read
+                // market_id concurrently, and none of them mutates it.
+                let market_id = unsafe { (*cell.get()).market_id };
+                if !router.market_for_this_handler(market_id as u64) {
+                    return;
+                }
+                // SAFETY: The market predicate above is exclusive, so this router alone in
+                // the matching barrier group creates a mutable reference for this sequence.
+                let cmd = unsafe { &mut *cell.get() };
                 if cmd.command == OrderCommandType::DepositFunds
                     || cmd.command == OrderCommandType::WithdrawFunds
                     || cmd.status == Status::Rejected
@@ -190,9 +204,14 @@ impl CoreEngine {
             }
         });
 
-        let events_handler = move |cmd: &mut OrderCommand, _sequence: i64, _end_of_batch: bool| {
-            events_handler.handle_processed_command(cmd);
-        };
+        let events_handler =
+            move |cell: &UnsafeCell<OrderCommand>, _sequence: i64, _end_of_batch: bool| {
+                // SAFETY: This events handler is the sole handler in this barrier group, so
+                // creating an exclusive reference to the command cannot alias another
+                // handler's reference.
+                let cmd = unsafe { &mut *cell.get() };
+                events_handler.handle_processed_command(cmd);
+            };
 
         // Build the disruptor pipeline with proper stage dependencies
         let producer = Self::build_disruptor_pipeline(
@@ -265,9 +284,9 @@ impl CoreEngine {
         enable_pinning: bool,
     ) -> OrderProducer
     where
-        X: FnMut(&mut OrderCommand, i64, bool) + Send + 'static,
-        Y: FnMut(&mut OrderCommand, i64, bool) + Send + 'static,
-        Z: FnMut(&mut OrderCommand, i64, bool) + Send + 'static,
+        X: FnMut(&UnsafeCell<OrderCommand>, i64, bool) + Send + 'static,
+        Y: FnMut(&UnsafeCell<OrderCommand>, i64, bool) + Send + 'static,
+        Z: FnMut(&UnsafeCell<OrderCommand>, i64, bool) + Send + 'static,
     {
         // Build the entire pipeline in one chain to maintain proper types
         info!(
@@ -470,7 +489,7 @@ pub mod test {
     use super::*;
 
     /// Type alias for test handler that intercepts order commands during testing
-    pub type TestHandler = Box<dyn FnMut(&mut OrderCommand, i64, bool) + Send + 'static>;
+    pub type TestHandler = Box<dyn FnMut(&UnsafeCell<OrderCommand>, i64, bool) + Send + 'static>;
 
     /// Test-specific core pinning configuration
     /// Uses higher core numbers to avoid conflicts with system processes
@@ -580,7 +599,7 @@ pub mod test {
         #[must_use]
         pub fn with_test_handler<F>(mut self, handler: F) -> Self
         where
-            F: FnMut(&mut OrderCommand, i64, bool) + Send + 'static,
+            F: FnMut(&UnsafeCell<OrderCommand>, i64, bool) + Send + 'static,
         {
             self.test_handler = Some(Box::new(handler));
             self
@@ -646,7 +665,11 @@ pub mod test {
             let order_factory = OrderCommand::default;
 
             let journaling_handler =
-                move |cmd: &mut OrderCommand, _sequence: i64, _end_of_batch: bool| {
+                move |cell: &UnsafeCell<OrderCommand>, _sequence: i64, _end_of_batch: bool| {
+                    // SAFETY: Test journaling is the sole handler in this barrier group, so
+                    // creating an exclusive reference to the command cannot alias another
+                    // handler's reference.
+                    let cmd = unsafe { &mut *cell.get() };
                     journaling_processor.journal_command(cmd);
                 };
 
@@ -660,7 +683,16 @@ pub mod test {
 
             let router_handlers = matching_engine_routers.into_iter().map(|mut router| {
                 let price_cache_clone = Arc::clone(&price_cache);
-                move |cmd: &mut OrderCommand, _sequence: i64, _end_of_batch: bool| {
+                move |cell: &UnsafeCell<OrderCommand>, _sequence: i64, _end_of_batch: bool| {
+                    // SAFETY: This is a shared scalar read; peer matching handlers may read
+                    // market_id concurrently, and none of them mutates it.
+                    let market_id = unsafe { (*cell.get()).market_id };
+                    if !router.market_for_this_handler(market_id as u64) {
+                        return;
+                    }
+                    // SAFETY: The market predicate above is exclusive, so this test router
+                    // alone creates a mutable reference for this sequence.
+                    let cmd = unsafe { &mut *cell.get() };
                     if cmd.command == OrderCommandType::DepositFunds
                         || cmd.command == OrderCommandType::WithdrawFunds
                         || cmd.status == Status::Rejected
@@ -674,7 +706,11 @@ pub mod test {
             let mut router_handlers_iter = router_handlers.into_iter();
 
             let events_handler =
-                move |cmd: &mut OrderCommand, _sequence: i64, _end_of_batch: bool| {
+                move |cell: &UnsafeCell<OrderCommand>, _sequence: i64, _end_of_batch: bool| {
+                    // SAFETY: The test events handler is the sole handler in this barrier
+                    // group, so creating this exclusive reference cannot alias another
+                    // handler's reference.
+                    let cmd = unsafe { &mut *cell.get() };
                     events_handler.handle_processed_command(cmd);
                 };
 
@@ -742,13 +778,13 @@ pub mod test {
             &self,
             buffer_size: usize,
             order_factory: fn() -> OrderCommand,
-            journaling_handler: impl FnMut(&mut OrderCommand, i64, bool) + Send + 'static,
+            journaling_handler: impl FnMut(&UnsafeCell<OrderCommand>, i64, bool) + Send + 'static,
             risk_engines: &RiskEngines,
             price_cache: &Arc<PriceCache>,
             router_handlers_iter: &mut impl Iterator<
-                Item = impl FnMut(&mut OrderCommand, i64, bool) + Send + 'static,
+                Item = impl FnMut(&UnsafeCell<OrderCommand>, i64, bool) + Send + 'static,
             >,
-            events_handler: impl FnMut(&mut OrderCommand, i64, bool) + Send + 'static,
+            events_handler: impl FnMut(&UnsafeCell<OrderCommand>, i64, bool) + Send + 'static,
             test_handler: TestHandler,
             core_pinning: TestCorePinning,
             enable_pinning: bool,

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -215,7 +215,7 @@ pub mod test {
     use super::*;
     use common::{OrderCommand, Status};
     use engine::{RiskEngines, test::TestEngineBuilder};
-    use std::sync::mpsc;
+    use std::{cell::UnsafeCell, sync::mpsc};
 
     /// Test engine instance with access to internals for testing
     pub struct TestEngine {
@@ -265,7 +265,11 @@ pub mod test {
     /// ```
     pub fn setup(specs: HashMap<u32, CoreMarketSpecification>) -> TestEngine {
         let (tx, rx) = mpsc::channel::<OrderCommand>();
-        let test_handler = move |cmd: &mut OrderCommand, _: i64, _: bool| {
+        let test_handler = move |cell: &UnsafeCell<OrderCommand>, _: i64, _: bool| {
+            // SAFETY: This test capture handler is alone after the events and_then()
+            // barrier, so creating this exclusive reference cannot alias another handler's
+            // reference.
+            let cmd = unsafe { &mut *cell.get() };
             if cmd.status != Status::Processing {
                 let _ = tx.send(cmd.clone());
             }

--- a/server/src/utils.rs
+++ b/server/src/utils.rs
@@ -25,8 +25,20 @@ macro_rules! create_risk_handler {
         // Clone Arc pointers to move into the closure
         let risk_engines = ::std::clone::Clone::clone($risk_engines);
         let price_cache = ::std::clone::Clone::clone($price_cache);
+        let shard_mask = risk_engines.len() as u64 - 1;
 
-        move |cmd: &mut $crate::engine::OrderCommand, _sequence: i64, _end_of_batch: bool| {
+        move |cell: &::std::cell::UnsafeCell<$crate::engine::OrderCommand>,
+              _sequence: i64,
+              _end_of_batch: bool| {
+            // SAFETY: This is a shared scalar read; peer R1 handlers may read user_id
+            // concurrently, and none of them mutates it.
+            let user_id = unsafe { (*cell.get()).user_id };
+            if (user_id & shard_mask) != $shard_id as u64 {
+                return;
+            }
+            // SAFETY: Journaling is ordered before R1, and the shard predicate above is
+            // exclusive, so only this R1 handler creates a mutable reference for this sequence.
+            let cmd = unsafe { &mut *cell.get() };
             let risk_engine = &risk_engines[$shard_id];
             risk_engine.pre_process_command(cmd, ::std::clone::Clone::clone(&price_cache));
         }
@@ -60,7 +72,13 @@ macro_rules! create_risk_r2_handler {
     ($shard_id:expr, $risk_engines:expr) => {{
         let risk_engines = $risk_engines.clone();
         let shard_mask = $risk_engines.len() as u64 - 1;
-        move |cmd: &mut OrderCommand, _sequence: i64, _end_of_batch: bool| {
+        move |cell: &::std::cell::UnsafeCell<OrderCommand>, _sequence: i64, _end_of_batch: bool| {
+            // SAFETY: R2 is the one handler group where taker and maker may be settled by
+            // different shards concurrently, so two handlers can hold `&mut` to the same
+            // command. This access is not sound. Making it sound requires
+            // `handle_trade_event` to take projected fields rather than `&mut OrderCommand`,
+            // which is a change in `processors/` and is tracked in issue #128.
+            let cmd = unsafe { &mut *cell.get() };
             if (cmd.status == Status::Rejected || cmd.status == Status::Processed) {
                 return;
             }
@@ -140,7 +158,13 @@ macro_rules! create_risk_r2_handler {
 #[macro_export]
 macro_rules! create_event_handler {
     ($events_handler:expr) => {{
-        move |cmd: &mut common::OrderCommand, _sequence: i64, _end_of_batch: bool| {
+        move |cell: &::std::cell::UnsafeCell<common::OrderCommand>,
+              _sequence: i64,
+              _end_of_batch: bool| {
+            // SAFETY: The events handler is the sole handler in this barrier group, so
+            // creating an exclusive reference to the command cannot alias another handler's
+            // reference.
+            let cmd = unsafe { &mut *cell.get() };
             $events_handler.handle_processed_command(cmd);
         }
     }};
@@ -173,7 +197,17 @@ macro_rules! create_matching_handler {
         let routers = $routers.clone();
         let shard_id = $shard_id;
         let price_cache = $price_cache.clone();
-        move |cmd: &mut OrderCommand, _sequence: i64, _end_of_batch: bool| {
+        move |cell: &::std::cell::UnsafeCell<OrderCommand>, _sequence: i64, _end_of_batch: bool| {
+            // SAFETY: This is a shared scalar read; peer matching handlers may read
+            // market_id concurrently, and none of them mutates it.
+            let market_id = unsafe { (*cell.get()).market_id };
+            let router = &routers[shard_id];
+            if !router.market_for_this_handler(market_id as u64) {
+                return;
+            }
+            // SAFETY: The market predicate above is exclusive, so this handler alone in
+            // the matching barrier group creates a mutable reference for this sequence.
+            let cmd = unsafe { &mut *cell.get() };
             // Non-op commands for order book processing
             if cmd.command == OrderCommandType::DepositFunds
                 || cmd.command == OrderCommandType::WithdrawFunds
@@ -181,7 +215,6 @@ macro_rules! create_matching_handler {
             {
                 return;
             }
-            let router = &routers[shard_id];
             let price_cache = price_cache.clone();
             router.process_order(cmd, price_cache);
         }


### PR DESCRIPTION
> Stacked on #158 (`fix/127-journaling-barrier`) and on **trade-vex/disruptor-rs#3**. Merge the
> disruptor PR and bump this pin to the resulting `main` SHA before merging here — the pin currently
> points at that PR's branch head so this builds and tests today.

## The problem

Every event handler in a barrier group received its own `&mut OrderCommand` to the **same** ring
slot. `spawn_processor` runs once per processor, so four R1 shards, four matching shards and four R2
shards each minted an exclusive reference to one object, concurrently, on different threads.

Two live `&mut` to one object is undefined behaviour by the language rules. `&mut T` carries a
`noalias` guarantee LLVM is entitled to exploit — hoisting loads across writes it believes
unobservable, caching values in registers across another thread's write, reordering. **This holds
whether or not the handlers write disjoint fields**, so "each shard only touches its own users" was
never a defence. It works today; nothing guarantees it survives a compiler upgrade.

## The fix

**Library side** (trade-vex/disruptor-rs#3): handlers receive `&UnsafeCell<E>` — the one type for
which aliasing plus interior mutation is defined — and the disjointness contract is written down
where callers meet it. No storage change was needed; `RingBuffer` already stored `UnsafeCell<E>` and
was discarding the cell to produce a `*mut E`.

**Here**: establish a single owner *before* creating the mutable reference. Creating the reference is
the UB, so it is not enough to only *write* under a shard predicate — the predicate has to gate the
reference itself:

```rust
// SAFETY: This is a shared scalar read; peer handlers may read user_id
// concurrently, and no handler in this barrier group mutates user_id.
let user_id = unsafe { (*cell.get()).user_id };
if (user_id & shard_mask) != $shard_id as u64 { return; }
// SAFETY: Journaling is ordered before R1, and the shard predicate above is
// exclusive, so only this R1 handler creates a mutable reference for this sequence.
let cmd = unsafe { &mut *cell.get() };
```

| Handler group | Status | Why |
|---|---|---|
| R1 | sound | shard predicate on `user_id` gates the reference |
| Matching | sound | shard predicate on `market_id` gates the reference |
| Journaling | sound | sole handler in its group — and #158 orders it before R1 |
| Events | sound | sole handler in its group |
| **R2** | **not sound — see #183** | taker and maker may be on different shards |

**The dependency on #158 is load-bearing.** Without the `and_then()` it inserts, journaling shares a
barrier with R1 and holds a whole-command `&mut` concurrently with R1's owner — which would defeat
the R1 fix entirely. That is why this is stacked rather than cut from develop.

## What this does not fix

R2 is entered by all four shards and does work if it owns *either* the taker or any maker, so two
handlers legitimately settle one command concurrently. There is no single owner to gate on.

A projection fix was written and **reverted during review**: settling into a local
`MatcherTradeEvent` and copying `maker_balance` back changes behaviour, because `settle_trade` writes
that field for *both* participants — so the surviving value would depend on whether taker and maker
share a shard. That is new nondeterminism in settlement, from a change meant to be a pure soundness
fix. R2 therefore keeps its whole-command `&mut` and a comment that says plainly it is not sound,
rather than one asserting a safety it does not have.

Tracked in **#183**, which needs `handle_trade_event` to take projected fields — a `processors/`
change, and one that should resolve the `maker_balance` double-write first.

`cargo test --workspace`: 153 passed, 0 failed. clippy: 0 warnings. No existing test body changed.

## Related

Closes #128

- vex-core #183 — the R2 residue split out of this.
- vex-core #127 / PR #158 — the barrier this is stacked on.
- trade-vex/disruptor-rs#3 — the library-side change this depends on.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of order processing across risk, matching, journaling, and event workflows.
  * Strengthened processing safeguards to prevent conflicting updates during concurrent operations.
  * Improved event sequencing to ensure dependent processing occurs in the correct order.
  * Updated test coverage and supporting infrastructure to reflect the improved processing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->